### PR TITLE
Manual refresh of summoner's data on summoner's page

### DIFF
--- a/app/api/config.py
+++ b/app/api/config.py
@@ -4,6 +4,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
 	matches_per_page: int = Field(default=20, ge=1)
+	summoner_sync_batch_size: int = Field(default=100, ge=1)
+	summoner_sync_stop_after: int = Field(default=20, ge=1)
 	default_champion_version: str = Field(default="14.5", min_length=1)
 	otel_enabled: bool = Field(default=True)
 	otel_service_name: str = Field(default="psi-api", min_length=1)

--- a/app/database/DAO.py
+++ b/app/database/DAO.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy import desc
+from sqlalchemy import desc, func
 from sqlalchemy.orm import joinedload
 
 import app.models.championModels
@@ -24,6 +24,13 @@ class DAO:
 
     def close(self):
         self.db.close()
+
+    def _get_summoner_row(self, summoner_name: str):
+        return (
+            self.db.query(Summoner)
+            .filter(func.lower(Summoner.summoner_name) == summoner_name.lower())
+            .first()
+        )
 
     def get_champion(self,champion_name :str,patch :list[str]):
         dao_champions = (
@@ -59,7 +66,7 @@ class DAO:
         )
 
     def get_summoner(self,summoner_name:str):
-        summoner = self.db.query(Summoner).filter(Summoner.summoner_name == summoner_name).first()
+        summoner = self._get_summoner_row(summoner_name)
         if summoner is None:
             return None
 
@@ -76,7 +83,7 @@ class DAO:
         )
 
     def get_matches(self, summoner_name, offset, count):
-        summoner = self.db.query(Summoner).filter(Summoner.summoner_name == summoner_name).first()
+        summoner = self._get_summoner_row(summoner_name)
         if not summoner:
             return []
         matches = (
@@ -129,7 +136,7 @@ class DAO:
         return result
 
     def summoner_has_matches(self, summoner_name: str) -> bool:
-        summoner = self.db.query(Summoner).filter(Summoner.summoner_name == summoner_name).first()
+        summoner = self._get_summoner_row(summoner_name)
         if not summoner:
             return False
 
@@ -139,6 +146,18 @@ class DAO:
             .first()
         )
         return match is not None
+
+    def get_match_ids_for_summoner(self, summoner_name: str) -> set[str]:
+        summoner = self._get_summoner_row(summoner_name)
+        if not summoner:
+            return set()
+
+        match_ids = (
+            self.db.query(MatchParticipant.match_id)
+            .filter(MatchParticipant.summoner_id == summoner.id)
+            .all()
+        )
+        return {match_id for (match_id,) in match_ids}
 
 
 

--- a/app/endpoints/endpoints.py
+++ b/app/endpoints/endpoints.py
@@ -1,6 +1,6 @@
 from urllib.parse import quote
 
-from fastapi import APIRouter, Depends, Form, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.encoders import jsonable_encoder
@@ -8,7 +8,7 @@ from app.api.config import settings
 
 from app.database.DAO import DAO
 
-from app.services.summonerServices import load_summoner_page
+from app.services.summonerServices import load_summoner_page, refresh_summoner_matches_service
 from app.services.championServices import get_champion_service
 
 router = APIRouter()
@@ -107,6 +107,25 @@ async def get_summoner(
             "summoner": summoner,
             "matchData": match_page
         },
+    )
+
+
+@router.post("/summoner/{name}/{tagline}/refresh")
+async def refresh_summoner(
+    request: Request,
+    name: str,
+    tagline: str,
+    dao: DAO = Depends(get_dao),
+):
+    refresh_result = refresh_summoner_matches_service(request, name, tagline, dao)
+    if refresh_result.summoner is None:
+        raise HTTPException(status_code=404, detail="Summoner not found")
+
+    return JSONResponse(
+        content={
+            "insertedCount": refresh_result.inserted_count,
+            "failedCount": refresh_result.failed_count,
+        }
     )
 
 @router.get("/champion/not-found")

--- a/app/endpoints/endpoints.py
+++ b/app/endpoints/endpoints.py
@@ -125,6 +125,8 @@ async def refresh_summoner(
         content={
             "insertedCount": refresh_result.inserted_count,
             "failedCount": refresh_result.failed_count,
+            "summonerName": refresh_result.summoner.name,
+            "summonerTagline": refresh_result.summoner.tagline,
         }
     )
 

--- a/app/riot/riotApiClient.py
+++ b/app/riot/riotApiClient.py
@@ -55,6 +55,11 @@ class RiotApiClient:
             f"/riot/account/v1/accounts/by-riot-id/{encoded_game_name}/{encoded_tagline}"
         )
 
+    def get_summoner_by_puuid(self, puuid: str) -> dict[str, Any]:
+        return self._get(
+            f"/riot/account/v1/accounts/by-puuid/{quote(puuid, safe='')}"
+        )
+
     def get_match_ids_by_puuid(
         self,
         puuid: str,

--- a/app/services/summonerServices.py
+++ b/app/services/summonerServices.py
@@ -242,11 +242,29 @@ def refresh_summoner_matches_service(
     puuid = summoner.puuid
     if not puuid:
         account_data = request.app.state.api_client.get_summoner_by_riot_id(name, tagline)
-        puuid = SummonerParser.parse(account_data).puuid
+        summoner = SummonerParser.parse(account_data)
+        puuid = summoner.puuid
+    else:
+        account_data = request.app.state.api_client.get_summoner_by_puuid(puuid)
+        remote_summoner = SummonerParser.parse(account_data)
+        
+        # Possible riot ID refresh
+        if (remote_summoner.name, remote_summoner.tagline) != (summoner.name, summoner.tagline):
+            summoner = Summoner(
+                puuid=summoner.puuid,
+                name=remote_summoner.name,
+                tagline=remote_summoner.tagline,
+                wins=summoner.wins,
+                gamesPlayed=summoner.gamesPlayed,
+                kills=summoner.kills,
+                deaths=summoner.deaths,
+                assists=summoner.assists,
+            )
+            dao.add_summoner(summoner)
 
     sync_result = sync_remote_matches(
         request,
-        f"{name}#{tagline}",
+        f"{summoner.name}#{summoner.tagline}",
         puuid,
         dao,
         start=0,
@@ -254,7 +272,7 @@ def refresh_summoner_matches_service(
         stop_after_total=settings.summoner_sync_stop_after,
     )
 
-    refreshed_summoner = dao.get_summoner(f"{name}#{tagline}") or summoner
+    refreshed_summoner = dao.get_summoner(f"{summoner.name}#{summoner.tagline}") or summoner
     return SummonerRefreshServiceResult(
         summoner=refreshed_summoner,
         inserted_count=sync_result.inserted_count,

--- a/app/services/summonerServices.py
+++ b/app/services/summonerServices.py
@@ -7,6 +7,7 @@ from opentelemetry.trace import Status, StatusCode
 from app.models.summonerModels import Summoner, MatchPage
 from app.database.DAO import DAO
 from app.riot.riotParsers import MatchParser, SummonerParser
+from app.api.config import settings
 
 LOGGER = logging.getLogger(__name__)
 
@@ -19,6 +20,17 @@ class MatchServiceResult(NamedTuple):
 class SummonerPageServiceResult(NamedTuple):
     summoner: Optional[Summoner]
     match_page: Optional[MatchPage]
+
+
+class MatchSyncResult(NamedTuple):
+    inserted_count: int
+    failed_count: int
+
+
+class SummonerRefreshServiceResult(NamedTuple):
+    summoner: Optional[Summoner]
+    inserted_count: int
+    failed_count: int
 
 
 def get_summoner_service(request: Request, name: str, tagline: str, dao: DAO) -> Optional[Summoner]:
@@ -44,6 +56,93 @@ def get_summoner_service(request: Request, name: str, tagline: str, dao: DAO) ->
             span.record_exception(exc)
             span.set_status(Status(StatusCode.ERROR))
             return None
+
+
+def sync_remote_matches(
+    request: Request,
+    summoner_name: str,
+    puuid: str,
+    dao: DAO,
+    *,
+    start: int,
+    batch_size: int,
+    stop_after_total: int | None = None,
+) -> MatchSyncResult:
+    tracer = trace.get_tracer(__name__)
+
+    with tracer.start_as_current_span("service.matches.sync_remote") as span:
+        span.set_attribute("matches.sync.start", start)
+        span.set_attribute("matches.sync.batch_size", batch_size)
+        if stop_after_total is not None:
+            span.set_attribute("matches.sync.stop_after_total", stop_after_total)
+
+        cached_match_ids = dao.get_match_ids_for_summoner(summoner_name)
+        span.set_attribute("matches.cached_id_count", len(cached_match_ids))
+        inserted_count = 0
+        failed_count = 0
+        current_start = start
+
+        while True:
+            try:
+                match_ids = request.app.state.api_client.get_match_ids_by_puuid(
+                    puuid,
+                    start=current_start,
+                    count=batch_size,
+                )
+            except httpx.RequestError as exc:
+                span.record_exception(exc)
+                span.set_attribute("matches.remote_fetch_failed", True)
+                LOGGER.warning(
+                    "Failed to fetch Riot match ids for %s: %s",
+                    summoner_name,
+                    exc,
+                )
+                failed_count += 1
+                break
+
+            if not match_ids:
+                break
+
+            for match_id in match_ids:
+                if match_id in cached_match_ids:
+                    continue
+
+                if dao.match_exist(match_id):
+                    cached_match_ids.add(match_id)
+                    continue
+
+                try:
+                    match_data = request.app.state.api_client.get_match_info_by_match_id(match_id)
+                    match = MatchParser.parse(match_data)
+                    inserted = dao.add_match(match)
+                    if inserted is not False:
+                        inserted_count += 1
+                        cached_match_ids.add(match_id)
+                except httpx.RequestError as exc:
+                    failed_count += 1
+                    span.record_exception(exc)
+                    LOGGER.warning(
+                        "Failed to fetch Riot match detail %s for %s: %s",
+                        match_id,
+                        summoner_name,
+                        exc,
+                    )
+                    continue
+
+                if stop_after_total is not None and inserted_count >= stop_after_total:
+                    break
+
+            if len(match_ids) < batch_size:
+                break
+
+            if stop_after_total is not None and inserted_count >= stop_after_total:
+                break
+
+            current_start += batch_size
+
+        span.set_attribute("matches.remote_count", inserted_count)
+        span.set_attribute("matches.remote_failures", failed_count)
+        return MatchSyncResult(inserted_count=inserted_count, failed_count=failed_count)
 
 
 def get_matches_service(
@@ -77,52 +176,19 @@ def get_matches_service(
                 puuid = SummonerParser.parse(account_data).puuid
 
             if puuid:
-                try:
-                    match_ids = request.app.state.api_client.get_match_ids_by_puuid(
-                        puuid,
-                        start=offset,
-                        count=query_count,
-                    )
-                except httpx.RequestError as exc:
-                    span.record_exception(exc)
-                    span.set_attribute("matches.remote_fetch_failed", True)
-                    LOGGER.warning(
-                        "Failed to fetch Riot match ids for %s: %s",
-                        summoner_name,
-                        exc,
-                    )
-                    match_ids = []
-
-                existing_ids = {str(match.match_id) for match in matches}
-                remote_matches = []
-                remote_failures = 0
-
-                for match_id in match_ids:
-                    if match_id in existing_ids:
-                        continue
-
-                    try:
-                        match_data = request.app.state.api_client.get_match_info_by_match_id(match_id)
-                        match = MatchParser.parse(match_data)
-                        remote_matches.append(match)
-                        dao.add_match(match)
-                        refreshed_from_remote = True
-                    except httpx.RequestError as exc:
-                        remote_failures += 1
-                        span.record_exception(exc)
-                        LOGGER.warning(
-                            "Failed to fetch Riot match detail %s for %s: %s",
-                            match_id,
-                            summoner_name,
-                            exc,
-                        )
-                        continue
-                    if len(matches) + len(remote_matches) >= query_count:
-                        break
-
-                matches = matches + remote_matches
-                span.set_attribute("matches.remote_count", len(remote_matches))
-                span.set_attribute("matches.remote_failures", remote_failures)
+                sync_result = sync_remote_matches(
+                    request,
+                    summoner_name,
+                    puuid,
+                    dao,
+                    start=offset,
+                    batch_size=settings.summoner_sync_batch_size,
+                    stop_after_total=query_count,
+                )
+                refreshed_from_remote = sync_result.inserted_count > 0
+                matches = dao.get_matches(summoner_name, offset, query_count)
+                span.set_attribute("matches.remote_count", sync_result.inserted_count)
+                span.set_attribute("matches.remote_failures", sync_result.failed_count)
 
         hasMore = len(matches) > count
         span.set_attribute("matches.has_more", hasMore)
@@ -160,4 +226,37 @@ def load_summoner_page(
     return SummonerPageServiceResult(
         summoner=summoner,
         match_page=match_result.match_page,
+    )
+
+
+def refresh_summoner_matches_service(
+    request: Request,
+    name: str,
+    tagline: str,
+    dao: DAO,
+) -> SummonerRefreshServiceResult:
+    summoner = get_summoner_service(request, name, tagline, dao)
+    if summoner is None:
+        return SummonerRefreshServiceResult(summoner=None, inserted_count=0, failed_count=0)
+
+    puuid = summoner.puuid
+    if not puuid:
+        account_data = request.app.state.api_client.get_summoner_by_riot_id(name, tagline)
+        puuid = SummonerParser.parse(account_data).puuid
+
+    sync_result = sync_remote_matches(
+        request,
+        f"{name}#{tagline}",
+        puuid,
+        dao,
+        start=0,
+        batch_size=settings.summoner_sync_batch_size,
+        stop_after_total=settings.summoner_sync_stop_after,
+    )
+
+    refreshed_summoner = dao.get_summoner(f"{name}#{tagline}") or summoner
+    return SummonerRefreshServiceResult(
+        summoner=refreshed_summoner,
+        inserted_count=sync_result.inserted_count,
+        failed_count=sync_result.failed_count,
     )

--- a/app/static/css/summoner.css
+++ b/app/static/css/summoner.css
@@ -139,6 +139,10 @@ input {
 }
 
 .section-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
     margin-bottom: 18px;
 }
 
@@ -149,6 +153,34 @@ input {
 .section-heading p {
     margin: 0;
     color: var(--muted);
+}
+
+.match-actions {
+    display: grid;
+    justify-items: end;
+    gap: 8px;
+}
+
+.refresh-button {
+    padding: 12px 18px;
+    border-radius: 999px;
+    border: 1px solid rgba(118, 212, 255, 0.3);
+    background: rgba(118, 212, 255, 0.1);
+    color: var(--text);
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.refresh-button:disabled {
+    opacity: 0.7;
+    cursor: progress;
+}
+
+.refresh-status {
+    margin: 0;
+    min-height: 1.2rem;
+    color: var(--muted);
+    font-size: 0.92rem;
 }
 
 .match-list {
@@ -305,6 +337,15 @@ input {
 
     .summary-grid {
         grid-template-columns: 1fr;
+    }
+
+    .section-heading {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .match-actions {
+        justify-items: start;
     }
 
     .match-summary {

--- a/app/static/js/summoner.js
+++ b/app/static/js/summoner.js
@@ -72,9 +72,13 @@ document.addEventListener("DOMContentLoaded", () => {
                 const data = await response.json();
                 const matchLabel = data.insertedCount === 1 ? "match" : "matches";
                 const refreshMessage = `Added ${data.insertedCount} new ${matchLabel}.`;
-                if (data.insertedCount > 0) {
-                    sessionStorage.setItem(refreshMessageStorageKey, refreshMessage);
-                    window.location.reload();
+                const refreshedName = data.summonerName ?? name;
+                const refreshedTagline = data.summonerTagline ?? tagline;
+                const summonerRouteChanged = refreshedName !== name || refreshedTagline !== tagline;
+                const refreshedRefreshMessageStorageKey = `summoner-refresh:${refreshedName}#${refreshedTagline}`;
+                if (data.insertedCount > 0 || summonerRouteChanged) {
+                    sessionStorage.setItem(refreshedRefreshMessageStorageKey, refreshMessage);
+                    window.location.assign(`/summoner/${encodeURIComponent(refreshedName)}/${encodeURIComponent(refreshedTagline)}`);
                     return;
                 }
 

--- a/app/static/js/summoner.js
+++ b/app/static/js/summoner.js
@@ -9,6 +9,21 @@ document.addEventListener("DOMContentLoaded", () => {
     const tagline = page.dataset.tagline;
     const puuid = page.dataset.puuid;
     const matchList = document.getElementById("match-list");
+    const refreshButton = document.getElementById("refresh-matches");
+    const refreshStatus = document.getElementById("refresh-status");
+    const refreshMessageStorageKey = `summoner-refresh:${name}#${tagline}`;
+
+    function setRefreshStatus(message) {
+        if (refreshStatus) {
+            refreshStatus.textContent = message;
+        }
+    }
+
+    const persistedRefreshMessage = sessionStorage.getItem(refreshMessageStorageKey);
+    if (persistedRefreshMessage) {
+        setRefreshStatus(persistedRefreshMessage);
+        sessionStorage.removeItem(refreshMessageStorageKey);
+    }
 
     function getMatchResult(match) {
         const viewedParticipant = match.participants.find((participant) => participant.puuid === puuid);
@@ -38,6 +53,41 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     const loadMoreButton = document.getElementById("load-more");
+
+    if (refreshButton) {
+        refreshButton.addEventListener("click", async () => {
+            refreshButton.disabled = true;
+            refreshButton.textContent = "Refreshing...";
+            setRefreshStatus("");
+
+            try {
+                const response = await fetch(`/summoner/${name}/${tagline}/refresh`, {
+                    method: "POST"
+                });
+
+                if (!response.ok) {
+                    throw new Error("Refresh failed");
+                }
+
+                const data = await response.json();
+                const matchLabel = data.insertedCount === 1 ? "match" : "matches";
+                const refreshMessage = `Added ${data.insertedCount} new ${matchLabel}.`;
+                if (data.insertedCount > 0) {
+                    sessionStorage.setItem(refreshMessageStorageKey, refreshMessage);
+                    window.location.reload();
+                    return;
+                }
+
+                setRefreshStatus(refreshMessage);
+                refreshButton.disabled = false;
+                refreshButton.textContent = "Refresh Data";
+            } catch (error) {
+                setRefreshStatus("Refresh failed. Please try again.");
+                refreshButton.disabled = false;
+                refreshButton.textContent = "Refresh Data";
+            }
+        });
+    }
 
     if (loadMoreButton) {
         loadMoreButton.addEventListener("click", async () => {

--- a/app/templates/summoner.html
+++ b/app/templates/summoner.html
@@ -47,8 +47,14 @@
 
         <section class="matches-section">
             <div class="section-heading">
-                <h2>Recent Matches</h2>
-                <p>Expand each row to inspect participants and match details.</p>
+                <div>
+                    <h2>Recent Matches</h2>
+                    <p>Expand each row to inspect participants and match details.</p>
+                </div>
+                <div class="match-actions">
+                    <button id="refresh-matches" class="refresh-button" type="button">Refresh Data</button>
+                    <p id="refresh-status" class="refresh-status" aria-live="polite"></p>
+                </div>
             </div>
 
             <div id="match-list" class="match-list">

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -44,6 +44,12 @@ class StubRiotApiClient:
             raise RuntimeError("Simulated upstream failure")
         return self._account_data
 
+    def get_summoner_by_puuid(self, _puuid: str) -> dict[str, Any]:
+        self.get_summoner_calls += 1
+        if self.raise_on_summoner_lookup:
+            raise RuntimeError("Simulated upstream failure")
+        return self._account_data
+
     def get_match_ids_by_puuid(self, _puuid: str, start: int, count: int) -> list[str]:
         self.get_match_ids_calls += 1
         return self._match_ids[start:start + count]

--- a/tests/integration/test_summoner_flow_e2e.py
+++ b/tests/integration/test_summoner_flow_e2e.py
@@ -88,6 +88,11 @@ def test_manual_refresh_skips_existing_matches(app_client, stub_api_client):
     refresh_response = app_client.post("/summoner/remoteplayer/euw/refresh")
 
     assert refresh_response.status_code == 200
-    assert refresh_response.json() == {"insertedCount": 0, "failedCount": 0}
+    assert refresh_response.json() == {
+        "insertedCount": 0,
+        "failedCount": 0,
+        "summonerName": "remoteplayer",
+        "summonerTagline": "euw",
+    }
     assert stub_api_client.get_match_ids_calls == match_id_calls_before_refresh + 1
     assert stub_api_client.get_match_info_calls == match_info_calls_before_refresh

--- a/tests/integration/test_summoner_flow_e2e.py
+++ b/tests/integration/test_summoner_flow_e2e.py
@@ -37,6 +37,17 @@ def test_cached_summoner_flow_html_and_ajax(app_client, seed_cached_summoner_dat
 
 
 @pytest.mark.integration
+def test_cached_summoner_lookup_is_case_insensitive(app_client, seed_cached_summoner_data, stub_api_client):
+    response = app_client.get("/summoner/CACHED/EUW")
+
+    assert response.status_code == 200
+    assert "cached#euw" in response.text
+    assert stub_api_client.get_summoner_calls == 0
+    assert stub_api_client.get_match_ids_calls == 0
+    assert stub_api_client.get_match_info_calls == 0
+
+
+@pytest.mark.integration
 def test_cache_miss_fetches_remote_once_and_persists(app_client, stub_api_client):
     first_response = app_client.get("/summoner/remoteplayer/euw?offset=0&ajax=true")
 
@@ -64,3 +75,19 @@ def test_cache_miss_fetches_remote_once_and_persists(app_client, stub_api_client
     )
 
     assert first_calls == second_calls
+
+
+@pytest.mark.integration
+def test_manual_refresh_skips_existing_matches(app_client, stub_api_client):
+    first_response = app_client.get("/summoner/remoteplayer/euw?offset=0&ajax=true")
+    assert first_response.status_code == 200
+
+    match_info_calls_before_refresh = stub_api_client.get_match_info_calls
+    match_id_calls_before_refresh = stub_api_client.get_match_ids_calls
+
+    refresh_response = app_client.post("/summoner/remoteplayer/euw/refresh")
+
+    assert refresh_response.status_code == 200
+    assert refresh_response.json() == {"insertedCount": 0, "failedCount": 0}
+    assert stub_api_client.get_match_ids_calls == match_id_calls_before_refresh + 1
+    assert stub_api_client.get_match_info_calls == match_info_calls_before_refresh

--- a/tests/test_dao.py
+++ b/tests/test_dao.py
@@ -160,3 +160,35 @@ def test_get_matches_applies_pagination(db_session):
 
     assert [match.match_id for match in first_page] == ["match-3", "match-2"]
     assert [match.match_id for match in second_page] == ["match-1"]
+
+
+def test_summoner_lookups_are_case_insensitive(db_session):
+    dao = DAO(db_session)
+    db_session.add(DaoSummoner(id="player-1", summoner_name="Alpha#EUW", games_played=2, games_won=1, kill=7, death=3, assist=9))
+    db_session.add(Champion.create_default(id="Ahri", name="Ahri"))
+    db_session.add(DaoMatch(id="match-1", created=100, ended=130, gametype="ranked", patch="14.5"))
+    db_session.add(
+        DaoMatchParticipant(
+            summoner_id="player-1",
+            match_id="match-1",
+            kill=1,
+            death=2,
+            assist=3,
+            gold=1000,
+            team=100,
+            won=True,
+            champion="Ahri",
+        )
+    )
+    db_session.commit()
+
+    summoner = dao.get_summoner("alpha#euw")
+    matches = dao.get_matches("ALPHA#euw", 0, 10)
+    has_matches = dao.summoner_has_matches("alpha#EUW")
+    match_ids = dao.get_match_ids_for_summoner("aLpHa#EuW")
+
+    assert summoner is not None
+    assert summoner.name == "Alpha"
+    assert [match.match_id for match in matches] == ["match-1"]
+    assert has_matches is True
+    assert match_ids == {"match-1"}

--- a/tests/test_summoner_endpoint.py
+++ b/tests/test_summoner_endpoint.py
@@ -4,7 +4,7 @@ from app.api.config import settings
 from app.endpoints import endpoints
 from app.main import app
 from app.models.summonerModels import Match, MatchPage, Summoner
-from app.services.summonerServices import SummonerPageServiceResult
+from app.services.summonerServices import SummonerPageServiceResult, SummonerRefreshServiceResult
 
 
 client = TestClient(app)
@@ -82,3 +82,19 @@ def test_not_found_page_displays_searched_summoner():
     assert response.status_code == 200
     assert "Summoner Not Found" in response.text
     assert "missing#euw" in response.text
+
+
+def test_summoner_refresh_returns_json(monkeypatch):
+    monkeypatch.setattr(
+        endpoints,
+        "refresh_summoner_matches_service",
+        lambda request, name, tagline, dao: SummonerRefreshServiceResult(
+            summoner=make_summoner(),
+            inserted_count=2,
+            failed_count=1,
+        ),
+    )
+
+    response = client.post("/summoner/test/euw/refresh")
+    assert response.status_code == 200
+    assert response.json() == {"insertedCount": 2, "failedCount": 1}

--- a/tests/test_summoner_endpoint.py
+++ b/tests/test_summoner_endpoint.py
@@ -97,4 +97,9 @@ def test_summoner_refresh_returns_json(monkeypatch):
 
     response = client.post("/summoner/test/euw/refresh")
     assert response.status_code == 200
-    assert response.json() == {"insertedCount": 2, "failedCount": 1}
+    assert response.json() == {
+        "insertedCount": 2,
+        "failedCount": 1,
+        "summonerName": "test",
+        "summonerTagline": "euw",
+    }

--- a/tests/test_summoner_services.py
+++ b/tests/test_summoner_services.py
@@ -21,6 +21,9 @@ class FakeApiClient:
     def get_summoner_by_riot_id(self, name, tagline):
         return self.account_data
 
+    def get_summoner_by_puuid(self, puuid):
+        return self.account_data
+
     def get_match_ids_by_puuid(self, puuid, start=0, count=20):
         return self.match_ids[start:start + count]
 
@@ -611,6 +614,9 @@ def test_refresh_summoner_matches_service_inserts_only_missing_matches():
             self.added_matches.append(match)
 
     class RefreshApiClient:
+        def get_summoner_by_puuid(self, puuid):
+            return {"puuid": puuid, "gameName": "test", "tagLine": "euw"}
+
         def get_match_ids_by_puuid(self, puuid, start=0, count=20):
             return ["m1", "m2", "m3"]
 
@@ -635,6 +641,63 @@ def test_refresh_summoner_matches_service_inserts_only_missing_matches():
     assert result.inserted_count == 2
     assert result.failed_count == 0
     assert [match.match_id for match in dao.added_matches] == ["m2", "m3"]
+
+
+def test_refresh_summoner_matches_service_updates_renamed_summoner():
+    class RefreshDAO:
+        def __init__(self):
+            self.saved_summoners = []
+            self.lookup_names = []
+
+        def get_summoner(self, summoner_name):
+            self.lookup_names.append(summoner_name)
+            if summoner_name == "Renamed#EUW":
+                return Summoner(
+                    puuid="cached-puuid",
+                    name="Renamed",
+                    tagline="EUW",
+                    wins=1,
+                    gamesPlayed=2,
+                    kills=3,
+                    deaths=4,
+                    assists=5,
+                )
+            return Summoner(
+                puuid="cached-puuid",
+                name="OldName",
+                tagline="EUW",
+                wins=1,
+                gamesPlayed=2,
+                kills=3,
+                deaths=4,
+                assists=5,
+            )
+
+        def get_match_ids_for_summoner(self, summoner_name):
+            return set()
+
+        def add_summoner(self, summoner):
+            self.saved_summoners.append(summoner)
+
+        def add_match(self, match):
+            raise AssertionError("match insertion is not part of this test")
+
+    class RefreshApiClient:
+        def get_summoner_by_puuid(self, puuid):
+            return {"puuid": puuid, "gameName": "Renamed", "tagLine": "EUW"}
+
+        def get_match_ids_by_puuid(self, puuid, start=0, count=20):
+            return []
+
+    dao = RefreshDAO()
+    request = make_request(RefreshApiClient())
+
+    result = refresh_summoner_matches_service(request, "OldName", "EUW", dao)
+
+    assert result.summoner is not None
+    assert result.summoner.name == "Renamed"
+    assert dao.saved_summoners[0].name == "Renamed"
+    assert dao.lookup_names[-1] == "Renamed#EUW"
 
 
 def test_refresh_summoner_matches_service_pages_past_first_batch_for_older_matches(monkeypatch):
@@ -669,6 +732,9 @@ def test_refresh_summoner_matches_service_pages_past_first_batch_for_older_match
     class RefreshApiClient:
         def __init__(self):
             self.starts = []
+
+        def get_summoner_by_puuid(self, puuid):
+            return {"puuid": puuid, "gameName": "test", "tagLine": "euw"}
 
         def get_match_ids_by_puuid(self, puuid, start=0, count=20):
             self.starts.append(start)
@@ -728,6 +794,9 @@ def test_refresh_uses_snapshot_then_match_exists_for_candidates_only():
             self.added_matches.append(match)
 
     class RefreshApiClient:
+        def get_summoner_by_puuid(self, puuid):
+            return {"puuid": puuid, "gameName": "test", "tagLine": "euw"}
+
         def get_match_ids_by_puuid(self, puuid, start=0, count=20):
             return ["m1", "m2", "m3"]
 

--- a/tests/test_summoner_services.py
+++ b/tests/test_summoner_services.py
@@ -2,8 +2,14 @@ from datetime import datetime
 from types import SimpleNamespace
 
 import httpx
+from app.api.config import settings
 from app.models.summonerModels import Match, Summoner
-from app.services.summonerServices import get_matches_service, get_summoner_service, load_summoner_page
+from app.services.summonerServices import (
+    get_matches_service,
+    get_summoner_service,
+    load_summoner_page,
+    refresh_summoner_matches_service,
+)
 
 
 class FakeApiClient:
@@ -44,6 +50,9 @@ class MockDAO:
     def summoner_has_matches(self, summoner_name):
         return True
 
+    def get_match_ids_for_summoner(self, summoner_name):
+        return set()
+
     def get_summoner(self, summoner_name):
         return Summoner(
             puuid="s1",
@@ -63,6 +72,9 @@ class MockSummonerDAO:
 
     def summoner_has_matches(self, summoner_name):
         return True
+
+    def get_match_ids_for_summoner(self, summoner_name):
+        return set()
 
     def get_summoner(self, summoner_name):
         if summoner_name == "test#euw":
@@ -112,6 +124,7 @@ def test_kda_zero_deaths():
     s = Summoner(puuid="s1", name="test", tagline="euw", wins=0, gamesPlayed=0, kills=10, deaths=0, assists=5)
     assert s.kda == 15
 
+
 def test_losses_calculated():
     s = Summoner(puuid="s1", name="test", tagline="euw", wins=5, gamesPlayed=10, kills=0, deaths=1, assists=0)
     assert s.losses == 5
@@ -154,6 +167,9 @@ def test_get_matches_has_more_is_false_when_page_is_exactly_full():
         def summoner_has_matches(self, summoner_name):
             return True
 
+        def get_match_ids_for_summoner(self, summoner_name):
+            return set()
+
         def get_summoner(self, summoner_name):
             return Summoner(
                 puuid="s1",
@@ -178,10 +194,13 @@ def test_get_matches_service_fetches_remote_only_when_cache_empty():
             self.saved_matches = []
 
         def get_matches(self, summoner_name, offset, count):
-            return []
+            return self.saved_matches[offset:offset + count]
 
         def summoner_has_matches(self, summoner_name):
             return False
+
+        def get_match_ids_for_summoner(self, summoner_name):
+            return set()
 
         def get_summoner(self, summoner_name):
             return Summoner(
@@ -194,6 +213,9 @@ def test_get_matches_service_fetches_remote_only_when_cache_empty():
                 deaths=0,
                 assists=0,
             )
+
+        def match_exist(self, match_id):
+            return False
 
         def add_match(self, match):
             self.saved_matches.append(match)
@@ -242,10 +264,13 @@ def test_get_matches_service_skips_failed_remote_match_detail():
             self.saved_matches = []
 
         def get_matches(self, summoner_name, offset, count):
-            return []
+            return self.saved_matches[offset:offset + count]
 
         def summoner_has_matches(self, summoner_name):
             return False
+
+        def get_match_ids_for_summoner(self, summoner_name):
+            return set()
 
         def get_summoner(self, summoner_name):
             return Summoner(
@@ -258,6 +283,9 @@ def test_get_matches_service_skips_failed_remote_match_detail():
                 deaths=0,
                 assists=0,
             )
+
+        def match_exist(self, match_id):
+            return False
 
         def add_match(self, match):
             self.saved_matches.append(match)
@@ -312,6 +340,9 @@ def test_load_summoner_page_returns_not_found_when_summoner_missing():
         def summoner_has_matches(self, summoner_name):
             return False
 
+        def get_match_ids_for_summoner(self, summoner_name):
+            return set()
+
         def get_summoner(self, summoner_name):
             return None
 
@@ -358,9 +389,15 @@ def test_load_summoner_page_refreshes_summoner_after_remote_matches():
             )
 
         def get_matches(self, summoner_name, offset, count):
-            return []
+            return self.saved_matches[offset:offset + count]
 
         def summoner_has_matches(self, summoner_name):
+            return False
+
+        def get_match_ids_for_summoner(self, summoner_name):
+            return set()
+
+        def match_exist(self, match_id):
             return False
 
         def add_match(self, match):
@@ -457,6 +494,9 @@ def test_get_matches_service_fetches_puuid_when_cached_summoner_has_empty_puuid(
         def summoner_has_matches(self, summoner_name):
             return False
 
+        def get_match_ids_for_summoner(self, summoner_name):
+            return set()
+
         def get_summoner(self, summoner_name):
             return Summoner(
                 puuid="",
@@ -510,6 +550,9 @@ def test_get_matches_service_does_not_fetch_remote_when_cache_exists():
         def summoner_has_matches(self, summoner_name):
             return True
 
+        def get_match_ids_for_summoner(self, summoner_name):
+            return {"m1"}
+
         def get_summoner(self, summoner_name):
             return Summoner(
                 puuid="cached-puuid",
@@ -540,3 +583,171 @@ def test_get_matches_service_does_not_fetch_remote_when_cache_exists():
     assert [match.match_id for match in result.match_page.matches] == ["m1"]
     assert dao.added_matches == []
 
+
+def test_refresh_summoner_matches_service_inserts_only_missing_matches():
+    class RefreshDAO:
+        def __init__(self):
+            self.added_matches = []
+
+        def get_summoner(self, summoner_name):
+            return Summoner(
+                puuid="cached-puuid",
+                name="test",
+                tagline="euw",
+                wins=1,
+                gamesPlayed=2,
+                kills=3,
+                deaths=4,
+                assists=5,
+            )
+
+        def get_match_ids_for_summoner(self, summoner_name):
+            return {"m1"}
+
+        def match_exist(self, match_id):
+            return match_id == "m1"
+
+        def add_match(self, match):
+            self.added_matches.append(match)
+
+    class RefreshApiClient:
+        def get_match_ids_by_puuid(self, puuid, start=0, count=20):
+            return ["m1", "m2", "m3"]
+
+        def get_match_info_by_match_id(self, match_id):
+            return {
+                "metadata": {"matchId": match_id},
+                "info": {
+                    "gameStartTimestamp": 1_700_000_000_000,
+                    "gameEndTimestamp": 1_700_000_600_000,
+                    "gameVersion": "14.5",
+                    "gameMode": "Ranked",
+                    "participants": [],
+                },
+            }
+
+    dao = RefreshDAO()
+    request = make_request(RefreshApiClient())
+
+    result = refresh_summoner_matches_service(request, "test", "euw", dao)
+
+    assert result.summoner is not None
+    assert result.inserted_count == 2
+    assert result.failed_count == 0
+    assert [match.match_id for match in dao.added_matches] == ["m2", "m3"]
+
+
+def test_refresh_summoner_matches_service_pages_past_first_batch_for_older_matches(monkeypatch):
+    monkeypatch.setattr(settings, "summoner_sync_batch_size", 3)
+    monkeypatch.setattr(settings, "summoner_sync_stop_after", 2)
+
+    class RefreshDAO:
+        def __init__(self):
+            self.added_matches = []
+
+        def get_summoner(self, summoner_name):
+            return Summoner(
+                puuid="cached-puuid",
+                name="test",
+                tagline="euw",
+                wins=1,
+                gamesPlayed=2,
+                kills=3,
+                deaths=4,
+                assists=5,
+            )
+
+        def get_match_ids_for_summoner(self, summoner_name):
+            return {"m1", "m2", "m3", "m4"}
+
+        def match_exist(self, match_id):
+            return match_id in {"m1", "m2", "m3", "m4"}
+
+        def add_match(self, match):
+            self.added_matches.append(match)
+
+    class RefreshApiClient:
+        def __init__(self):
+            self.starts = []
+
+        def get_match_ids_by_puuid(self, puuid, start=0, count=20):
+            self.starts.append(start)
+            all_match_ids = ["m1", "m2", "m3", "m4", "m5", "m6"]
+            return all_match_ids[start:start + count]
+
+        def get_match_info_by_match_id(self, match_id):
+            return {
+                "metadata": {"matchId": match_id},
+                "info": {
+                    "gameStartTimestamp": 1_700_000_000_000,
+                    "gameEndTimestamp": 1_700_000_600_000,
+                    "gameVersion": "14.5",
+                    "gameMode": "Ranked",
+                    "participants": [],
+                },
+            }
+
+    dao = RefreshDAO()
+    api_client = RefreshApiClient()
+    request = make_request(api_client)
+
+    result = refresh_summoner_matches_service(request, "test", "euw", dao)
+
+    assert result.inserted_count == 2
+    assert result.failed_count == 0
+    assert [match.match_id for match in dao.added_matches] == ["m5", "m6"]
+    assert api_client.starts == [0, 3]
+
+
+def test_refresh_uses_snapshot_then_match_exists_for_candidates_only():
+    class RefreshDAO:
+        def __init__(self):
+            self.added_matches = []
+            self.match_exists_calls = []
+
+        def get_summoner(self, summoner_name):
+            return Summoner(
+                puuid="cached-puuid",
+                name="test",
+                tagline="euw",
+                wins=1,
+                gamesPlayed=2,
+                kills=3,
+                deaths=4,
+                assists=5,
+            )
+
+        def get_match_ids_for_summoner(self, summoner_name):
+            return {"m1"}
+
+        def match_exist(self, match_id):
+            self.match_exists_calls.append(match_id)
+            return match_id == "m2"
+
+        def add_match(self, match):
+            self.added_matches.append(match)
+
+    class RefreshApiClient:
+        def get_match_ids_by_puuid(self, puuid, start=0, count=20):
+            return ["m1", "m2", "m3"]
+
+        def get_match_info_by_match_id(self, match_id):
+            return {
+                "metadata": {"matchId": match_id},
+                "info": {
+                    "gameStartTimestamp": 1_700_000_000_000,
+                    "gameEndTimestamp": 1_700_000_600_000,
+                    "gameVersion": "14.5",
+                    "gameMode": "Ranked",
+                    "participants": [],
+                },
+            }
+
+    dao = RefreshDAO()
+    request = make_request(RefreshApiClient())
+
+    result = refresh_summoner_matches_service(request, "test", "euw", dao)
+
+    assert result.inserted_count == 1
+    assert dao.match_exists_calls == ["m2", "m3"]
+    assert [match.match_id for match in dao.added_matches] == ["m3"]


### PR DESCRIPTION
Addition of refresh button to summoner's page. Refresh does two things:

- Loads summoner's matches that are not already present in the database (amount of them is defined in config)
- Updates Riot ID if present state in Riot API doesn't match the one in the database (refreshes URL too)