### PR TITLE
Queue types incorporated into the app, replacing gamemode type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN pip install -r requirements.txt
 
 COPY ./app ./app
 COPY ./scripts ./scripts
+COPY ./tools ./tools
 COPY ./alembic ./alembic
 COPY ./alembic.ini ./alembic.ini
 

--- a/alembic/versions/1dbf24eac9c2_match_queue_id.py
+++ b/alembic/versions/1dbf24eac9c2_match_queue_id.py
@@ -1,0 +1,105 @@
+"""replace match gametype with queue_id
+
+Revision ID: 1dbf24eac9c2
+Revises: 7b6613e2b9a1
+Create Date: 2026-04-23 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "1dbf24eac9c2"
+down_revision: Union[str, Sequence[str], None] = "7b6613e2b9a1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("match", sa.Column("queue_id", sa.Integer(), nullable=True))
+    op.create_index(op.f("ix_match_queue_id"), "match", ["queue_id"], unique=False)
+    op.create_foreign_key(
+        "fk_match_queue_id_queues",
+        "match",
+        "queues",
+        ["queue_id"],
+        ["queue_id"],
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION increment_analyzed_count()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            resolved_gametype TEXT;
+        BEGIN
+            SELECT q.description
+            INTO resolved_gametype
+            FROM queues q
+            WHERE q.queue_id = NEW.queue_id;
+
+            IF resolved_gametype IS NULL THEN
+                RETURN NEW;
+            END IF;
+
+            INSERT INTO matches_analyzed (gametype, patch, count)
+            VALUES (resolved_gametype, NEW.patch, 1) ON CONFLICT (gametype, patch)
+            DO UPDATE
+            SET count = matches_analyzed.count + 1;
+
+            RETURN NEW;
+        END;
+        $$  LANGUAGE plpgsql;
+
+        CREATE OR REPLACE FUNCTION increment_champion_stats()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            resolved_gametype TEXT;
+        BEGIN
+            SELECT q.description
+            INTO resolved_gametype
+            FROM match m
+            JOIN queues q ON q.queue_id = m.queue_id
+            WHERE m.id = NEW.match_id;
+
+            IF resolved_gametype IS NULL THEN
+                RETURN NEW;
+            END IF;
+
+            INSERT INTO champion_stats (champion_id, patch, gametype,games_played,games_won,games_banned,kill,assist,death)
+            SELECT
+                NEW.champion,
+                m.patch,
+                resolved_gametype,
+                1,
+                CASE WHEN NEW.won THEN 1 ELSE 0 END,
+                0,
+                NEW.kill,
+                NEW.assist,
+                NEW.death
+            FROM match m
+            WHERE m.id = NEW.match_id
+            ON CONFLICT (champion_id,gametype, patch)
+            DO UPDATE
+            SET
+                games_played = champion_stats.games_played + 1,
+                games_won = COALESCE(champion_stats.games_won, 0) +
+                    CASE WHEN NEW.won THEN 1 ELSE 0 END,
+                kill = champion_stats.kill + NEW.kill,
+                assist = champion_stats.assist + NEW.assist,
+                death = champion_stats.death + NEW.death;
+
+            RETURN NEW;
+        END;
+        $$  LANGUAGE plpgsql;
+        """
+    )
+    op.drop_column("match", "gametype")
+
+
+def downgrade() -> None:
+    op.add_column("match", sa.Column("gametype", sa.String(), nullable=True))
+    op.drop_constraint("fk_match_queue_id_queues", "match", type_="foreignkey")
+    op.drop_index(op.f("ix_match_queue_id"), table_name="match")
+    op.drop_column("match", "queue_id")

--- a/alembic/versions/5c2b9f7f7a11_queue_ids_for_derived_tables.py
+++ b/alembic/versions/5c2b9f7f7a11_queue_ids_for_derived_tables.py
@@ -1,0 +1,173 @@
+"""replace derived gametype columns with queue_id
+
+Revision ID: 5c2b9f7f7a11
+Revises: 1dbf24eac9c2
+Create Date: 2026-04-23 00:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "5c2b9f7f7a11"
+down_revision: Union[str, Sequence[str], None] = "1dbf24eac9c2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index(op.f("ix_champion_stats_champion_id"), table_name="champion_stats")
+    op.drop_index(op.f("ix_champion_stats_gametype"), table_name="champion_stats")
+    op.drop_index(op.f("ix_champion_stats_patch"), table_name="champion_stats")
+    op.drop_table("champion_stats")
+
+    op.drop_index(op.f("ix_matches_analyzed_gametype"), table_name="matches_analyzed")
+    op.drop_index(op.f("ix_matches_analyzed_patch"), table_name="matches_analyzed")
+    op.drop_table("matches_analyzed")
+
+    op.create_table(
+        "champion_stats",
+        sa.Column("champion_id", sa.String(), nullable=False),
+        sa.Column("patch", sa.String(), nullable=False),
+        sa.Column("queue_id", sa.Integer(), nullable=False),
+        sa.Column("games_played", sa.Integer(), nullable=True),
+        sa.Column("games_won", sa.Integer(), nullable=True),
+        sa.Column("games_banned", sa.Integer(), nullable=True),
+        sa.Column("kill", sa.Integer(), nullable=True),
+        sa.Column("assist", sa.Integer(), nullable=True),
+        sa.Column("death", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["champion_id"], ["champion.id"]),
+        sa.ForeignKeyConstraint(["queue_id"], ["queues.queue_id"]),
+        sa.PrimaryKeyConstraint("champion_id", "patch", "queue_id"),
+    )
+    op.create_index(op.f("ix_champion_stats_champion_id"), "champion_stats", ["champion_id"], unique=False)
+    op.create_index(op.f("ix_champion_stats_patch"), "champion_stats", ["patch"], unique=False)
+    op.create_index(op.f("ix_champion_stats_queue_id"), "champion_stats", ["queue_id"], unique=False)
+
+    op.create_table(
+        "matches_analyzed",
+        sa.Column("patch", sa.String(), nullable=False),
+        sa.Column("queue_id", sa.Integer(), nullable=False),
+        sa.Column("count", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["queue_id"], ["queues.queue_id"]),
+        sa.PrimaryKeyConstraint("patch", "queue_id"),
+    )
+    op.create_index(op.f("ix_matches_analyzed_patch"), "matches_analyzed", ["patch"], unique=False)
+    op.create_index(op.f("ix_matches_analyzed_queue_id"), "matches_analyzed", ["queue_id"], unique=False)
+
+    op.execute(
+        """
+        INSERT INTO matches_analyzed (patch, queue_id, count)
+        SELECT
+            m.patch,
+            m.queue_id,
+            COUNT(*)
+        FROM match m
+        WHERE m.queue_id IS NOT NULL
+        GROUP BY m.patch, m.queue_id;
+
+        INSERT INTO champion_stats (champion_id, patch, queue_id, games_played, games_won, games_banned, kill, assist, death)
+        SELECT
+            mp.champion,
+            m.patch,
+            m.queue_id,
+            COUNT(*) AS games_played,
+            SUM(CASE WHEN mp.won THEN 1 ELSE 0 END) AS games_won,
+            0 AS games_banned,
+            SUM(mp.kill) AS kill,
+            SUM(mp.assist) AS assist,
+            SUM(mp.death) AS death
+        FROM match_participant mp
+        JOIN match m ON m.id = mp.match_id
+        WHERE m.queue_id IS NOT NULL
+        GROUP BY mp.champion, m.patch, m.queue_id;
+
+        CREATE OR REPLACE FUNCTION increment_analyzed_count()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            IF NEW.queue_id IS NULL THEN
+                RETURN NEW;
+            END IF;
+
+            INSERT INTO matches_analyzed (patch, queue_id, count)
+            VALUES (NEW.patch, NEW.queue_id, 1) ON CONFLICT (patch, queue_id)
+            DO UPDATE
+            SET count = matches_analyzed.count + 1;
+
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+
+        CREATE OR REPLACE FUNCTION increment_champion_stats()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            INSERT INTO champion_stats (champion_id, patch, queue_id, games_played, games_won, games_banned, kill, assist, death)
+            SELECT
+                NEW.champion,
+                m.patch,
+                m.queue_id,
+                1,
+                CASE WHEN NEW.won THEN 1 ELSE 0 END,
+                0,
+                NEW.kill,
+                NEW.assist,
+                NEW.death
+            FROM match m
+            WHERE m.id = NEW.match_id
+              AND m.queue_id IS NOT NULL
+            ON CONFLICT (champion_id, patch, queue_id)
+            DO UPDATE
+            SET
+                games_played = champion_stats.games_played + 1,
+                games_won = COALESCE(champion_stats.games_won, 0) +
+                    CASE WHEN NEW.won THEN 1 ELSE 0 END,
+                kill = champion_stats.kill + NEW.kill,
+                assist = champion_stats.assist + NEW.assist,
+                death = champion_stats.death + NEW.death;
+
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_champion_stats_queue_id"), table_name="champion_stats")
+    op.drop_index(op.f("ix_champion_stats_patch"), table_name="champion_stats")
+    op.drop_index(op.f("ix_champion_stats_champion_id"), table_name="champion_stats")
+    op.drop_table("champion_stats")
+
+    op.drop_index(op.f("ix_matches_analyzed_queue_id"), table_name="matches_analyzed")
+    op.drop_index(op.f("ix_matches_analyzed_patch"), table_name="matches_analyzed")
+    op.drop_table("matches_analyzed")
+
+    op.create_table(
+        "champion_stats",
+        sa.Column("champion_id", sa.String(), nullable=False),
+        sa.Column("patch", sa.String(), nullable=False),
+        sa.Column("gametype", sa.String(), nullable=False),
+        sa.Column("games_played", sa.Integer(), nullable=True),
+        sa.Column("games_won", sa.Integer(), nullable=True),
+        sa.Column("games_banned", sa.Integer(), nullable=True),
+        sa.Column("kill", sa.Integer(), nullable=True),
+        sa.Column("assist", sa.Integer(), nullable=True),
+        sa.Column("death", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["champion_id"], ["champion.id"]),
+        sa.PrimaryKeyConstraint("champion_id", "patch", "gametype"),
+    )
+    op.create_index(op.f("ix_champion_stats_champion_id"), "champion_stats", ["champion_id"], unique=False)
+    op.create_index(op.f("ix_champion_stats_gametype"), "champion_stats", ["gametype"], unique=False)
+    op.create_index(op.f("ix_champion_stats_patch"), "champion_stats", ["patch"], unique=False)
+
+    op.create_table(
+        "matches_analyzed",
+        sa.Column("patch", sa.String(), nullable=False),
+        sa.Column("gametype", sa.String(), nullable=False),
+        sa.Column("count", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("patch", "gametype"),
+    )
+    op.create_index(op.f("ix_matches_analyzed_gametype"), "matches_analyzed", ["gametype"], unique=False)
+    op.create_index(op.f("ix_matches_analyzed_patch"), "matches_analyzed", ["patch"], unique=False)

--- a/alembic/versions/7b6613e2b9a1_queues_table.py
+++ b/alembic/versions/7b6613e2b9a1_queues_table.py
@@ -1,0 +1,79 @@
+"""queues table
+
+Revision ID: 7b6613e2b9a1
+Revises: b53b79809d27
+Create Date: 2026-04-22 20:30:00.000000
+
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "7b6613e2b9a1"
+down_revision: Union[str, Sequence[str], None] = "b53b79809d27"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _normalize_description(description: str | None) -> str | None:
+    if description is None:
+        return None
+
+    if description.endswith(" games"):
+        return description[:-6]
+
+    if description.endswith(" Games"):
+        return description[:-6]
+
+    return description
+
+
+def _load_queues() -> list[dict[str, object]]:
+    queues_path = Path(__file__).resolve().parents[2] / "tools" / "queues.json"
+    with queues_path.open(encoding="utf-8") as file:
+        raw_queues = json.load(file)
+
+    return [
+        {
+            "queue_id": queue["queueId"],
+            "map": queue["map"],
+            "description": _normalize_description(queue["description"]),
+            "notes": queue["notes"],
+        }
+        for queue in raw_queues
+    ]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "queues",
+        sa.Column("queue_id", sa.Integer(), autoincrement=False, nullable=False),
+        sa.Column("map", sa.String(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("queue_id"),
+    )
+    op.create_index(op.f("ix_queues_queue_id"), "queues", ["queue_id"], unique=False)
+
+    queue_table = sa.table(
+        "queues",
+        sa.column("queue_id", sa.Integer()),
+        sa.column("map", sa.String()),
+        sa.column("description", sa.Text()),
+        sa.column("notes", sa.Text()),
+    )
+    op.bulk_insert(queue_table, _load_queues())
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_queues_queue_id"), table_name="queues")
+    op.drop_table("queues")

--- a/app/database/DAO.py
+++ b/app/database/DAO.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import joinedload
 import app.models.championModels
 import app.models.summonerModels
 from app.database.database import SessionLocal
-from app.database.models import Match, Summoner, MatchParticipant, Champion, ChampionStats, MatchesAnalyzed
+from app.database.models import Match, Summoner, MatchParticipant, Champion, ChampionStats, MatchesAnalyzed, Queue
 from app.utils.utils import split_name
 from app.utils.versioning import version_sort_key
 
@@ -32,6 +32,16 @@ class DAO:
             .filter(func.lower(Summoner.summoner_name) == summoner_name.lower())
             .first()
         )
+
+    @staticmethod
+    def _get_queue_description(queue: Queue | None, queue_id: int | None) -> str:
+        if queue is not None and queue.description:
+            return queue.description
+        if queue is not None and queue.map:
+            return queue.map
+        if queue_id is not None:
+            return "Unknown Queue"
+        return ""
 
     def get_champion_versions(self, champion_name: str) -> list[str]:
         versions = (
@@ -65,20 +75,21 @@ class DAO:
             matches_analyzed_query = matches_analyzed_query.filter(MatchesAnalyzed.patch.in_(patch))
 
         matches_analyzed = matches_analyzed_query.all()
-        analyzed_lookup = {(ma.patch, ma.gametype): ma.count for ma in matches_analyzed}
+        analyzed_lookup = {(ma.patch, ma.queue_id): ma.count for ma in matches_analyzed}
         result = []
         for dao_champion in dao_champions:
             result.append(
                 app.models.championModels.ChampionStats(
                     version=dao_champion.patch,
-                    gamemode=dao_champion.gametype,
+                    queueId=dao_champion.queue_id,
+                    queueDescription=self._get_queue_description(dao_champion.ChampionStats_Queue, dao_champion.queue_id),
                     wins=dao_champion.games_won,
                     gamesPlayed=dao_champion.games_played,
                     kills=dao_champion.kill,
                     deaths=dao_champion.death,
                     assists=dao_champion.assist,
                     banned=dao_champion.games_banned,
-                    matchesAnalyzed=analyzed_lookup.get((dao_champion.patch, dao_champion.gametype), 0)
+                    matchesAnalyzed=analyzed_lookup.get((dao_champion.patch, dao_champion.queue_id), 0)
                 )
             )
         return app.models.championModels.Champion(
@@ -118,7 +129,8 @@ class DAO:
                 joinedload(Match.Match_MatchParticipant)  # load participants for each match
                 .joinedload(MatchParticipant.MatchParticipant_Summoner),  # load participant's summoner info
                 joinedload(Match.Match_MatchParticipant)
-                .joinedload(MatchParticipant.MatchParticipant_Champion)  # load participant's champion info
+                .joinedload(MatchParticipant.MatchParticipant_Champion),  # load participant's champion info
+                joinedload(Match.Match_Queue),
             )
             .all()
         )
@@ -149,7 +161,7 @@ class DAO:
                     start=datetime.fromtimestamp(match.created),
                     end=datetime.fromtimestamp(match.ended),
                     version=match.patch,
-                    mode=match.gametype,
+                    queueDescription=self._get_queue_description(match.Match_Queue, match.queue_id),
                     participants=participants_list
                 )
             )
@@ -200,7 +212,7 @@ class DAO:
                     id=match_id,
                     created=int(match.start.timestamp()),
                     ended=int(match.end.timestamp()),
-                    gametype=match.mode,
+                    queue_id=match.queueId,
                     patch=match.version,
                 )
 

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, null
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Text, null
 from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
@@ -75,6 +75,15 @@ class Champion(Base):
     @classmethod
     def create_default(cls, id: str,name:str = None):
         return Champion(id=id,champion_name=name)
+
+
+class Queue(Base):
+    __tablename__ = "queues"
+
+    queue_id = Column(Integer, primary_key=True, index=True, autoincrement=False)
+    map = Column(String, nullable=True)
+    description = Column(Text, nullable=True)
+    notes = Column(Text, nullable=True)
 
 class SummonerChampion(Base):
     __tablename__ = "summoner_champion"

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -26,10 +26,11 @@ class Match(Base):
     id = Column(String, primary_key=True, index=True)
     created = Column(Integer)
     ended = Column(Integer)
-    gametype=Column(String)
+    queue_id = Column(Integer, ForeignKey("queues.queue_id"), nullable=True, index=True)
     patch=Column(String)
 
     Match_MatchParticipant = relationship("MatchParticipant", back_populates="MatchParticipant_Match")
+    Match_Queue = relationship("Queue")
 
 class MatchParticipant(Base):
     __tablename__ = "match_participant"
@@ -53,7 +54,7 @@ class ChampionStats(Base):
     __tablename__ = "champion_stats"
     champion_id = Column(String, ForeignKey("champion.id"), primary_key=True, index=True)
     patch = Column(String,primary_key=True, index=True)
-    gametype = Column(String, primary_key=True, index=True)
+    queue_id = Column(Integer, ForeignKey("queues.queue_id"), primary_key=True, index=True)
     games_played = Column(Integer)
     games_won = Column(Integer)
     games_banned = Column(Integer)
@@ -62,6 +63,7 @@ class ChampionStats(Base):
     death = Column(Integer)
 
     ChampionStats_Champion = relationship("Champion", back_populates="Champion_ChampionStats")
+    ChampionStats_Queue = relationship("Queue")
 
 class Champion(Base):
     __tablename__ = "champion"
@@ -98,7 +100,7 @@ class SummonerChampion(Base):
 class MatchesAnalyzed(Base):
     __tablename__ = "matches_analyzed"
     patch = Column(String,primary_key=True, index=True)
-    gametype = Column(String, primary_key=True, index=True)
+    queue_id = Column(Integer, ForeignKey("queues.queue_id"), primary_key=True, index=True)
     count = Column(Integer)
 
 

--- a/app/endpoints/endpoints.py
+++ b/app/endpoints/endpoints.py
@@ -202,7 +202,7 @@ async def get_champion(
                 "availableVersions": available_versions,
                 "championImagePath": champion_image_path,
                 "selectedVersionStats": selected_stats,
-                "trendSeriesByMode": trend_series,
+                "trendSeriesByQueue": trend_series,
                 # Backward compatibility for previous JS/tests
                 "championStats": selected_stats,
             }

--- a/app/instrumentation/otel.py
+++ b/app/instrumentation/otel.py
@@ -12,12 +12,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
 from opentelemetry.semconv.resource import ResourceAttributes
 
-#logger
 import logging
-from opentelemetry._logs import set_logger_provider
-from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
-from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
-from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from app.api.config import settings
 from app.database.database import engine
 
@@ -47,6 +42,11 @@ HTTPXClientInstrumentor = _MissingHTTPXClientInstrumentor
 SQLAlchemyInstrumentor = _MissingSQLAlchemyInstrumentor
 OTLPSpanExporter = None
 OTLPMetricExporter = None
+set_logger_provider = None
+OTLPLogExporter = None
+LoggerProvider = None
+LoggingHandler = None
+BatchLogRecordProcessor = None
 
 try:
     from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -54,6 +54,10 @@ try:
     from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
     from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+    from opentelemetry._logs import set_logger_provider
+    from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+    from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+    from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 except Exception as exc:  # pragma: no cover - exercised indirectly in test envs
     _OTEL_IMPORT_ERROR = exc
 
@@ -109,26 +113,31 @@ def setup_telemetry(app: FastAPI) -> Callable[[], None]:
     app.state.tracer = trace.get_tracer(settings.otel_service_name)
     app.state.meter = metrics.get_meter(settings.otel_service_name)
 
-    #logger
-    # 1. Initialize LoggerProvider
-    log_provider = LoggerProvider(resource=resource)
-    set_logger_provider(log_provider)
+    log_provider = None
+    if (
+        OTLPLogExporter is not None
+        and set_logger_provider is not None
+        and LoggerProvider is not None
+        and LoggingHandler is not None
+        and BatchLogRecordProcessor is not None
+    ):
+        log_provider = LoggerProvider(resource=resource)
+        set_logger_provider(log_provider)
 
-    # 2. Configure OTLP Log Exporter
-    log_exporter = OTLPLogExporter(
-        endpoint=settings.otel_exporter_otlp_endpoint,
-        insecure=settings.otel_exporter_otlp_insecure,
-    )
+        log_exporter = OTLPLogExporter(
+            endpoint=settings.otel_exporter_otlp_endpoint,
+            insecure=settings.otel_exporter_otlp_insecure,
+        )
+        log_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
 
-    # 3. Add Processor and Handler
-    log_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
-
-    # This handler automatically injects trace_id and span_id into the log record
-    otel_handler = LoggingHandler(level=logging.INFO, logger_provider=log_provider)
-
-    # 4. Attach to the root logger or specific app loggers
-    logging.getLogger().addHandler(otel_handler)
-    logging.getLogger("uvicorn").addHandler(otel_handler)# uvicorn logs todo: nedded ?
+        otel_handler = LoggingHandler(level=logging.INFO, logger_provider=log_provider)
+        logging.getLogger().addHandler(otel_handler)
+        logging.getLogger("uvicorn").addHandler(otel_handler)
+    elif _OTEL_IMPORT_ERROR is not None:
+        LOGGER.warning(
+            "Telemetry log exporting is unavailable; traces and metrics remain enabled. Cause: %s",
+            _OTEL_IMPORT_ERROR,
+        )
 
     LOGGER.info(
         "Telemetry initialized for service '%s' (environment=%s).",
@@ -139,6 +148,7 @@ def setup_telemetry(app: FastAPI) -> Callable[[], None]:
     def _shutdown() -> None:
         meter_provider.shutdown()
         provider.shutdown()
-        log_provider.shutdown()
+        if log_provider is not None:
+            log_provider.shutdown()
 
     return _shutdown

--- a/app/models/championModels.py
+++ b/app/models/championModels.py
@@ -1,9 +1,10 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List
 
 class ChampionStats(BaseModel):
     version: str
-    gamemode: str
+    queueId: int = Field(default=0, exclude=True)
+    queueDescription: str
     wins: int
     gamesPlayed: int
     kills: int
@@ -13,7 +14,7 @@ class ChampionStats(BaseModel):
     matchesAnalyzed: int
 
     def __str__(self):
-        return f" ChampionStats version={self.version} gamemode={self.gamemode} wins={self.wins}"
+        return f" ChampionStats version={self.version} queueDescription={self.queueDescription} wins={self.wins}"
     
     @property
     def winrate(self):

--- a/app/models/summonerModels.py
+++ b/app/models/summonerModels.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from datetime import datetime
 from typing import List
 
@@ -19,7 +19,8 @@ class Match(BaseModel):
     start: datetime
     end: datetime
     version: str
-    mode: str
+    queueId: int = Field(default=0, exclude=True)
+    queueDescription: str
     participants: List[MatchParticipant]
 
 class Summoner(BaseModel):

--- a/app/riot/riotParsers.py
+++ b/app/riot/riotParsers.py
@@ -34,7 +34,8 @@ class MatchParser:
             start=datetime.fromtimestamp(info.get("gameStartTimestamp", 0) / 1000, tz=UTC),
             end=datetime.fromtimestamp(info.get("gameEndTimestamp", 0) / 1000, tz=UTC),
             version=normalize_version(info.get("gameVersion", "")),
-            mode=info.get("gameMode", ""),
+            queueId=info.get("queueId", 0),
+            queueDescription="",
             participants=[
                 MatchParticipantParser.parse(participant)
                 for participant in participants

--- a/app/services/championServices.py
+++ b/app/services/championServices.py
@@ -28,14 +28,14 @@ def _accumulate_stat(entry: dict[str, int], stat: ChampionStats) -> None:
     entry["matchesAnalyzed"] += stat.matchesAnalyzed
 
 
-def _aggregate_by_mode_and_version(stats: list[ChampionStats]) -> dict[str, dict[str, dict[str, int]]]:
+def _aggregate_by_queue_and_version(stats: list[ChampionStats]) -> dict[str, dict[str, dict[str, int]]]:
     grouped: dict[str, dict[str, dict[str, int]]] = defaultdict(
         lambda: defaultdict(_empty_aggregate_bucket)
     )
 
     for stat in stats:
         normalized = normalize_version(stat.version)
-        _accumulate_stat(grouped[stat.gamemode][normalized], stat)
+        _accumulate_stat(grouped[stat.queueDescription][normalized], stat)
 
     return grouped
 
@@ -49,18 +49,18 @@ def get_available_versions(stats: list[ChampionStats]) -> list[str]:
 
 
 def aggregate_stats_for_version(stats: list[ChampionStats], version: str) -> list[ChampionStats]:
-    grouped = _aggregate_by_mode_and_version(stats)
+    grouped = _aggregate_by_queue_and_version(stats)
 
     aggregated = []
-    for gamemode in sorted(grouped):
-        values = grouped[gamemode].get(version)
+    for queue_description in sorted(grouped):
+        values = grouped[queue_description].get(version)
         if values is None:
             continue
 
         aggregated.append(
             ChampionStats(
                 version=version,
-                gamemode=gamemode,
+                queueDescription=queue_description,
                 wins=values["wins"],
                 gamesPlayed=values["gamesPlayed"],
                 kills=values["kills"],
@@ -77,7 +77,7 @@ def aggregate_stats_for_version(stats: list[ChampionStats], version: str) -> lis
 def serialize_stat(stat: ChampionStats) -> dict:
     return {
         "version": stat.version,
-        "gamemode": stat.gamemode,
+        "queueDescription": stat.queueDescription,
         "wins": stat.wins,
         "gamesPlayed": stat.gamesPlayed,
         "kills": stat.kills,
@@ -94,14 +94,14 @@ def serialize_stat(stat: ChampionStats) -> dict:
 
 
 def build_trend_series(stats: list[ChampionStats]) -> list[dict]:
-    grouped = _aggregate_by_mode_and_version(stats)
+    grouped = _aggregate_by_queue_and_version(stats)
 
     trend_series = []
-    for gamemode, by_version in grouped.items():
+    for queue_description, by_version in grouped.items():
         ordered_versions = sorted(by_version, key=version_sort_key)
         trend_series.append(
             {
-                "gamemode": gamemode,
+                "queueDescription": queue_description,
                 "points": [
                     {
                         "version": version,
@@ -123,7 +123,7 @@ def build_trend_series(stats: list[ChampionStats]) -> list[dict]:
             }
         )
 
-    return sorted(trend_series, key=lambda series: series["gamemode"])
+    return sorted(trend_series, key=lambda series: series["queueDescription"])
 
 def get_champion_service(name: str, version: list[str] | None, dao: DAO) -> Optional[Champion]:
     tracer = trace.get_tracer(__name__)

--- a/app/static/js/champion.js
+++ b/app/static/js/champion.js
@@ -46,15 +46,15 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
-    function normalizeSeries(seriesByMode) {
-        if (!Array.isArray(seriesByMode)) {
+    function normalizeSeries(seriesByQueue) {
+        if (!Array.isArray(seriesByQueue)) {
             return [];
         }
 
-        return seriesByMode
+        return seriesByQueue
             .filter((series) => series && Array.isArray(series.points))
             .map((series) => ({
-                gamemode: series.gamemode || "Unknown",
+                queueDescription: series.queueDescription || "Unknown Queue",
                 points: series.points.filter((point) => point && point.version),
             }))
             .filter((series) => series.points.length > 0);
@@ -119,7 +119,7 @@ document.addEventListener("DOMContentLoaded", () => {
             const row = document.createElement("tr");
             row.innerHTML = `
                 <td>${stat.version}</td>
-                <td>${stat.gamemode}</td>
+                <td>${stat.queueDescription}</td>
                 <td>${stat.totalMatchesPlayed ?? stat.gamesPlayed}</td>
                 <td>${formatNumber(stat.winrate, "%")}</td>
                 <td>${formatNumber(stat.kda)}</td>
@@ -130,13 +130,13 @@ document.addEventListener("DOMContentLoaded", () => {
         });
     }
 
-    function renderCharts(seriesByMode) {
+    function renderCharts(seriesByQueue) {
         if (typeof Chart === "undefined") {
             console.error("Chart.js is unavailable; skipping chart rendering.");
             return;
         }
 
-        const safeSeries = normalizeSeries(seriesByMode);
+        const safeSeries = normalizeSeries(seriesByQueue);
 
         Object.values(chartInstances).forEach((chart) => chart.destroy());
         Object.keys(chartInstances).forEach((key) => delete chartInstances[key]);
@@ -170,7 +170,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 const color = palette[index % palette.length];
 
                 return {
-                    label: series.gamemode,
+                    label: series.queueDescription,
                     data: allVersions.map((version) => valueByVersion.get(version) ?? null),
                     borderColor: color,
                     backgroundColor: `${color}55`,
@@ -254,7 +254,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
 
         renderTable(payload.selectedVersionStats || payload.championStats || []);
-        renderCharts(payload.trendSeriesByMode || []);
+        renderCharts(payload.trendSeriesByQueue || []);
         setChampionImages(payload.championImagePath || "");
     }
 

--- a/app/static/js/summoner.js
+++ b/app/static/js/summoner.js
@@ -109,7 +109,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 summaryButton.dataset.matchId = match.match_id;
                 summaryButton.innerHTML = `
                     <span>Match ${match.match_id}</span>
-                    <span>${match.mode}</span>
+                    <span>${match.queueDescription}</span>
                     <span>${matchResult.charAt(0).toUpperCase() + matchResult.slice(1)} | Patch ${match.version}</span>
                 `;
                 summaryButton.addEventListener("click", () => toggleMatch(match.match_id));

--- a/app/templates/champion.html
+++ b/app/templates/champion.html
@@ -28,7 +28,7 @@
                     <p class="eyebrow">Champion Breakdown</p>
                     <h1>{{ championData.name }}</h1>
                     <p class="hero-subtitle">
-                        Explore patch-specific performance and compare trends across multiple versions and game modes.
+                        Explore patch-specific performance and compare trends across multiple versions and queue types.
                     </p>
                 </div>
                 <div class="hero-portrait-shell {% if not champion_image_path %}hidden{% endif %}">
@@ -66,7 +66,7 @@
                 <table>
                     <tr>
                         <th>Patch</th>
-                        <th>Mode</th>
+                        <th>Queue</th>
                         <th>Total Matches Played</th>
                         <th>Winrate</th>
                         <th>KDA</th>
@@ -78,7 +78,7 @@
                     {% for stat in championData.championStats %}
                     <tr>
                         <td>{{ stat.version }}</td>
-                        <td>{{ stat.gamemode }}</td>
+                        <td>{{ stat.queueDescription }}</td>
                         <td>{{ stat.gamesPlayed }}</td>
                         <td>{{ "%.2f"|format(stat.winrate) }}%</td>
                         <td>{{ "%.2f"|format(stat.kda) }}</td>
@@ -94,7 +94,7 @@
         <section class="trend-panel">
             <div class="section-heading">
                 <h2>Performance Progression Across Versions</h2>
-                <p>Each chart compares gamemodes over every available patch for this champion.</p>
+                <p>Each chart compares queues over every available patch for this champion.</p>
             </div>
             <div class="chart-grid">
                 <article class="chart-card">

--- a/app/templates/summoner.html
+++ b/app/templates/summoner.html
@@ -68,7 +68,7 @@
                 <article class="match match--{{ match_state.result }}">
                     <button type="button" class="match-summary match-summary--{{ match_state.result }}" data-match-id="{{ match.match_id }}">
                         <span>Match {{ match.match_id }}</span>
-                        <span>{{ match.mode }}</span>
+                        <span>{{ match.queueDescription }}</span>
                         <span>{{ match_state.result|capitalize }} | Patch {{ match.version }}</span>
                     </button>
                     <div id="match-{{ match.match_id }}" class="match-details" style="display:none">

--- a/tests/fixtures/riot_api/match_infos.json
+++ b/tests/fixtures/riot_api/match_infos.json
@@ -5,7 +5,7 @@
       "gameStartTimestamp": 1712500000000,
       "gameEndTimestamp": 1712501800000,
       "gameVersion": "14.5",
-      "gameMode": "CLASSIC",
+      "queueId": 420,
       "participants": [
         {
           "puuid": "remote-player-puuid",
@@ -28,7 +28,7 @@
       "gameStartTimestamp": 1712510000000,
       "gameEndTimestamp": 1712511700000,
       "gameVersion": "14.5",
-      "gameMode": "CLASSIC",
+      "queueId": 420,
       "participants": [
         {
           "puuid": "remote-player-puuid",
@@ -51,7 +51,7 @@
       "gameStartTimestamp": 1712520000000,
       "gameEndTimestamp": 1712521900000,
       "gameVersion": "14.5",
-      "gameMode": "CLASSIC",
+      "queueId": 420,
       "participants": [
         {
           "puuid": "remote-player-puuid",
@@ -74,7 +74,7 @@
       "gameStartTimestamp": 1712530000000,
       "gameEndTimestamp": 1712532100000,
       "gameVersion": "14.4",
-      "gameMode": "CLASSIC",
+      "queueId": 420,
       "participants": [
         {
           "puuid": "remote-player-puuid",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,6 +20,7 @@ from app.database.models import (
     Match,
     MatchParticipant,
     MatchesAnalyzed,
+    Queue,
     Summoner,
 )
 from app.endpoints import endpoints
@@ -136,6 +137,7 @@ def app_client(monkeypatch: pytest.MonkeyPatch, dao: DAO, stub_api_client: StubR
 def seed_cached_summoner_data(db_session: Session) -> dict[str, str]:
     summoner_id = "cached-puuid"
     db_session.add(Champion(id="Ahri", champion_name="Ahri"))
+    db_session.add(Queue(queue_id=420, map="Summoner's Rift", description="Ranked Solo", notes=None))
     db_session.add(
         Summoner(
             id=summoner_id,
@@ -155,7 +157,7 @@ def seed_cached_summoner_data(db_session: Session) -> dict[str, str]:
                 id=match_id,
                 created=1712000000 + (index * 1000),
                 ended=1712001200 + (index * 1000),
-                gametype="CLASSIC",
+                queue_id=420,
                 patch="14.5",
             )
         )
@@ -182,6 +184,7 @@ def seed_cached_summoner_data(db_session: Session) -> dict[str, str]:
 def seed_partial_matches_data(db_session: Session) -> dict[str, str]:
     summoner_id = "partial-puuid"
     db_session.add(Champion(id="Lux", champion_name="Lux"))
+    db_session.add(Queue(queue_id=420, map="Summoner's Rift", description="Ranked Solo", notes=None))
     db_session.add(
         Summoner(
             id=summoner_id,
@@ -201,7 +204,7 @@ def seed_partial_matches_data(db_session: Session) -> dict[str, str]:
                 id=match_id,
                 created=1712100000 + (index * 1000),
                 ended=1712101200 + (index * 1000),
-                gametype="CLASSIC",
+                queue_id=420,
                 patch="14.5",
             )
         )
@@ -230,11 +233,12 @@ def seed_champion_stats_data(db_session: Session) -> dict[str, str]:
     champion_name = "ahri"
 
     db_session.add(Champion(id=champion_id, champion_name=champion_name))
+    db_session.add(Queue(queue_id=420, map="Summoner's Rift", description="Ranked Solo", notes=None))
     db_session.add(
         ChampionStats(
             champion_id=champion_id,
             patch="14.5",
-            gametype="CLASSIC",
+            queue_id=420,
             games_played=20,
             games_won=12,
             games_banned=8,
@@ -247,7 +251,7 @@ def seed_champion_stats_data(db_session: Session) -> dict[str, str]:
         ChampionStats(
             champion_id=champion_id,
             patch="14.4",
-            gametype="CLASSIC",
+            queue_id=420,
             games_played=15,
             games_won=8,
             games_banned=4,
@@ -256,8 +260,8 @@ def seed_champion_stats_data(db_session: Session) -> dict[str, str]:
             death=45,
         )
     )
-    db_session.add(MatchesAnalyzed(patch="14.5", gametype="CLASSIC", count=200))
-    db_session.add(MatchesAnalyzed(patch="14.4", gametype="CLASSIC", count=150))
+    db_session.add(MatchesAnalyzed(patch="14.5", queue_id=420, count=200))
+    db_session.add(MatchesAnalyzed(patch="14.4", queue_id=420, count=150))
 
     db_session.commit()
 

--- a/tests/test_champion_endpoint.py
+++ b/tests/test_champion_endpoint.py
@@ -14,7 +14,7 @@ def make_champion(name: str = "Ahri") -> Champion:
         championStats=[
             ChampionStats(
                 version="14.5",
-                gamemode="Ranked Solo",
+                queueDescription="Ranked Solo",
                 wins=10,
                 gamesPlayed=20,
                 kills=100,
@@ -62,9 +62,11 @@ def test_champion_ajax_response(monkeypatch):
     assert len(data["championStats"]) == 1
     assert data["selectedVersion"] == "14.5"
     assert data["availableVersions"] == ["14.5"]
-    assert "trendSeriesByMode" in data
+    assert "trendSeriesByQueue" in data
     assert "selectedVersionStats" in data
     assert "championImagePath" in data
+    assert data["selectedVersionStats"][0]["queueDescription"] == "Ranked Solo"
+    assert "gamemode" not in data["selectedVersionStats"][0]
 
 
 def test_champion_ajax_filters_version(monkeypatch):
@@ -73,7 +75,7 @@ def test_champion_ajax_filters_version(monkeypatch):
         championStats=[
             ChampionStats(
                 version="14.4",
-                gamemode="Ranked Solo",
+                queueDescription="Ranked Solo",
                 wins=8,
                 gamesPlayed=16,
                 kills=80,
@@ -109,7 +111,7 @@ def test_champion_ajax_switches_stats_between_versions(monkeypatch):
         championStats=[
             ChampionStats(
                 version="16.8.777.3456",
-                gamemode="Ranked Solo",
+                queueDescription="Ranked Solo",
                 wins=8,
                 gamesPlayed=20,
                 kills=80,
@@ -120,7 +122,7 @@ def test_champion_ajax_switches_stats_between_versions(monkeypatch):
             ),
             ChampionStats(
                 version="16.8.778.9823",
-                gamemode="Ranked Solo",
+                queueDescription="Ranked Solo",
                 wins=12,
                 gamesPlayed=20,
                 kills=110,
@@ -131,7 +133,7 @@ def test_champion_ajax_switches_stats_between_versions(monkeypatch):
             ),
             ChampionStats(
                 version="16.9.100.1",
-                gamemode="Ranked Solo",
+                queueDescription="Ranked Solo",
                 wins=15,
                 gamesPlayed=20,
                 kills=130,
@@ -155,5 +157,5 @@ def test_champion_ajax_switches_stats_between_versions(monkeypatch):
     assert data_168["selectedVersionStats"][0]["wins"] == 20
     assert data_169["selectedVersionStats"][0]["wins"] == 15
     assert data_168["availableVersions"] == ["16.9", "16.8"]
-    assert "trendSeriesByMode" in data_168
+    assert "trendSeriesByQueue" in data_168
     assert "championImagePath" in data_168

--- a/tests/test_champion_services.py
+++ b/tests/test_champion_services.py
@@ -19,7 +19,7 @@ class MockChampionDAO:
 def create_champion():
     stats = ChampionStats(
         version="14.5",
-        gamemode="Ranked",
+        queueDescription="Ranked Solo",
         wins=10,
         gamesPlayed=15,
         kills=100,
@@ -70,54 +70,54 @@ def test_champion_service_returns_none_when_missing():
 
 
 def test_winrate():
-    stats = ChampionStats(version="14.5", gamemode="Ranked", wins=7, gamesPlayed=10, kills=0, deaths=0, assists=0, banned=0, matchesAnalyzed=10)
+    stats = ChampionStats(version="14.5", queueDescription="Ranked Solo", wins=7, gamesPlayed=10, kills=0, deaths=0, assists=0, banned=0, matchesAnalyzed=10)
     assert stats.winrate == 70
 
 
 def test_winrate_edge():
-    stats = ChampionStats(version="14.5", gamemode="Ranked", wins=0, gamesPlayed=0, kills=0, deaths=0, assists=0, banned=0, matchesAnalyzed=10)
+    stats = ChampionStats(version="14.5", queueDescription="Ranked Solo", wins=0, gamesPlayed=0, kills=0, deaths=0, assists=0, banned=0, matchesAnalyzed=10)
     assert stats.winrate == -1
 
 
 def test_kda():
-    stats = ChampionStats(version="14.5", gamemode="Ranked", wins=1, gamesPlayed=0, kills=10, deaths=2, assists=6, banned=0, matchesAnalyzed=1)
+    stats = ChampionStats(version="14.5", queueDescription="Ranked Solo", wins=1, gamesPlayed=0, kills=10, deaths=2, assists=6, banned=0, matchesAnalyzed=1)
     assert stats.kda == 8
 
 
 def test_kda_zero_deaths():
-    stats = ChampionStats(version="14.5", gamemode="Ranked", wins=1, gamesPlayed=0, kills=10, deaths=0, assists=5, banned=0, matchesAnalyzed=1)
+    stats = ChampionStats(version="14.5", queueDescription="Ranked Solo", wins=1, gamesPlayed=0, kills=10, deaths=0, assists=5, banned=0, matchesAnalyzed=1)
     assert stats.kda == 15
 
 
 def test_pickrate():
-    stats = ChampionStats(version="14.5", gamemode="Ranked", wins=10, gamesPlayed=20, kills=0, deaths=0, assists=0, banned=0, matchesAnalyzed=200)
+    stats = ChampionStats(version="14.5", queueDescription="Ranked Solo", wins=10, gamesPlayed=20, kills=0, deaths=0, assists=0, banned=0, matchesAnalyzed=200)
     assert stats.pickrate == 10
 
 
 def test_pickrate_zero_games():
-    stats = ChampionStats(version="14.5", gamemode="Ranked", wins=10, gamesPlayed=20, kills=0, deaths=0, assists=0, banned=0, matchesAnalyzed=0)
+    stats = ChampionStats(version="14.5", queueDescription="Ranked Solo", wins=10, gamesPlayed=20, kills=0, deaths=0, assists=0, banned=0, matchesAnalyzed=0)
     assert stats.pickrate == 0
 
 
 def test_banrate():
-    stats = ChampionStats(version="14.5", gamemode="Ranked", wins=10, gamesPlayed=20, kills=0, deaths=0, assists=0, banned=20, matchesAnalyzed=100)
+    stats = ChampionStats(version="14.5", queueDescription="Ranked Solo", wins=10, gamesPlayed=20, kills=0, deaths=0, assists=0, banned=20, matchesAnalyzed=100)
     assert stats.banrate == 20
 
 
 def test_banrate_zero_games():
-    stats = ChampionStats(version="14.5", gamemode="Ranked", wins=10, gamesPlayed=20, kills=0, deaths=0, assists=0, banned=20, matchesAnalyzed=0)
+    stats = ChampionStats(version="14.5", queueDescription="Ranked Solo", wins=10, gamesPlayed=20, kills=0, deaths=0, assists=0, banned=20, matchesAnalyzed=0)
     assert stats.banrate == 0
 
 def test_champion_stats_to_string():
-    stats = ChampionStats(version="14.5", gamemode="Ranked", wins=10, gamesPlayed=20, kills=100, deaths=50, assists=80, banned=10, matchesAnalyzed=200)
-    expected_str = " ChampionStats version=14.5 gamemode=Ranked wins=10"
+    stats = ChampionStats(version="14.5", queueDescription="Ranked Solo", wins=10, gamesPlayed=20, kills=100, deaths=50, assists=80, banned=10, matchesAnalyzed=200)
+    expected_str = " ChampionStats version=14.5 queueDescription=Ranked Solo wins=10"
     assert str(stats) == expected_str
 
 
 def test_serialize_stat_has_expected_keys():
     stats = ChampionStats(
         version="14.5",
-        gamemode="Ranked",
+        queueDescription="Ranked Solo",
         wins=10,
         gamesPlayed=15,
         kills=100,
@@ -131,7 +131,7 @@ def test_serialize_stat_has_expected_keys():
 
     assert {
         "version",
-        "gamemode",
+        "queueDescription",
         "gamesPlayed",
         "totalMatchesPlayed",
         "winrate",
@@ -143,9 +143,9 @@ def test_serialize_stat_has_expected_keys():
 
 def test_get_available_versions_normalizes_major_minor():
     stats = [
-        ChampionStats(version="16.8.777.3456", gamemode="Ranked", wins=1, gamesPlayed=1, kills=1, deaths=1, assists=1, banned=0, matchesAnalyzed=10),
-        ChampionStats(version="16.8.778.9823", gamemode="Ranked", wins=1, gamesPlayed=1, kills=1, deaths=1, assists=1, banned=0, matchesAnalyzed=10),
-        ChampionStats(version="16.9.100.1", gamemode="Ranked", wins=1, gamesPlayed=1, kills=1, deaths=1, assists=1, banned=0, matchesAnalyzed=10),
+        ChampionStats(version="16.8.777.3456", queueDescription="Ranked Solo", wins=1, gamesPlayed=1, kills=1, deaths=1, assists=1, banned=0, matchesAnalyzed=10),
+        ChampionStats(version="16.8.778.9823", queueDescription="Ranked Solo", wins=1, gamesPlayed=1, kills=1, deaths=1, assists=1, banned=0, matchesAnalyzed=10),
+        ChampionStats(version="16.9.100.1", queueDescription="Ranked Solo", wins=1, gamesPlayed=1, kills=1, deaths=1, assists=1, banned=0, matchesAnalyzed=10),
     ]
 
     assert get_available_versions(stats) == ["16.9", "16.8"]
@@ -153,13 +153,13 @@ def test_get_available_versions_normalizes_major_minor():
 
 def test_aggregate_stats_for_version_sums_modes():
     stats = [
-        ChampionStats(version="16.8.777.3456", gamemode="Ranked", wins=4, gamesPlayed=10, kills=20, deaths=10, assists=15, banned=2, matchesAnalyzed=100),
-        ChampionStats(version="16.8.778.9823", gamemode="Ranked", wins=6, gamesPlayed=10, kills=25, deaths=10, assists=20, banned=3, matchesAnalyzed=120),
-        ChampionStats(version="16.8.778.9823", gamemode="ARAM", wins=3, gamesPlayed=8, kills=18, deaths=9, assists=12, banned=1, matchesAnalyzed=120),
+        ChampionStats(version="16.8.777.3456", queueDescription="Ranked Solo", wins=4, gamesPlayed=10, kills=20, deaths=10, assists=15, banned=2, matchesAnalyzed=100),
+        ChampionStats(version="16.8.778.9823", queueDescription="Ranked Solo", wins=6, gamesPlayed=10, kills=25, deaths=10, assists=20, banned=3, matchesAnalyzed=120),
+        ChampionStats(version="16.8.778.9823", queueDescription="ARAM", wins=3, gamesPlayed=8, kills=18, deaths=9, assists=12, banned=1, matchesAnalyzed=120),
     ]
 
     aggregated = aggregate_stats_for_version(stats, "16.8")
-    ranked = next(item for item in aggregated if item.gamemode == "Ranked")
+    ranked = next(item for item in aggregated if item.queueDescription == "Ranked Solo")
 
     assert ranked.version == "16.8"
     assert ranked.wins == 10
@@ -169,9 +169,9 @@ def test_aggregate_stats_for_version_sums_modes():
 
 def test_build_trend_series_groups_by_normalized_version():
     stats = [
-        ChampionStats(version="16.8.777.3456", gamemode="Ranked", wins=4, gamesPlayed=10, kills=20, deaths=10, assists=15, banned=2, matchesAnalyzed=100),
-        ChampionStats(version="16.8.778.9823", gamemode="Ranked", wins=6, gamesPlayed=10, kills=25, deaths=10, assists=20, banned=3, matchesAnalyzed=120),
-        ChampionStats(version="16.9.100.1", gamemode="Ranked", wins=7, gamesPlayed=12, kills=30, deaths=12, assists=22, banned=4, matchesAnalyzed=140),
+        ChampionStats(version="16.8.777.3456", queueDescription="Ranked Solo", wins=4, gamesPlayed=10, kills=20, deaths=10, assists=15, banned=2, matchesAnalyzed=100),
+        ChampionStats(version="16.8.778.9823", queueDescription="Ranked Solo", wins=6, gamesPlayed=10, kills=25, deaths=10, assists=20, banned=3, matchesAnalyzed=120),
+        ChampionStats(version="16.9.100.1", queueDescription="Ranked Solo", wins=7, gamesPlayed=12, kills=30, deaths=12, assists=22, banned=4, matchesAnalyzed=140),
     ]
 
     trend_series = build_trend_series(stats)

--- a/tests/test_dao.py
+++ b/tests/test_dao.py
@@ -12,6 +12,7 @@ from app.database.models import (
     Match as DaoMatch,
     MatchParticipant as DaoMatchParticipant,
     MatchesAnalyzed,
+    Queue,
     Summoner as DaoSummoner,
 )
 from app.models.summonerModels import Match, MatchParticipant, Summoner
@@ -96,6 +97,7 @@ def test_add_champion(db_session):
 def test_add_match(db_session):
     dao = DAO(db_session)
     db_session.add(Champion.create_default(id="champ_akali", name="Akali"))
+    db_session.add(Queue(queue_id=420, map="Summoner's Rift", description="Ranked Solo", notes=None))
     db_session.commit()
 
     match = Match(
@@ -103,7 +105,8 @@ def test_add_match(db_session):
         start=datetime(2026, 4, 7, 12, 0, tzinfo=UTC),
         end=datetime(2026, 4, 7, 12, 30, tzinfo=UTC),
         version="1.27.2",
-        mode="summoners rift",
+        queueId=420,
+        queueDescription="Ranked Solo",
         participants=[
             MatchParticipant(
                 puuid="player-1",
@@ -146,12 +149,13 @@ def test_get_matches_applies_pagination(db_session):
     dao = DAO(db_session)
     db_session.add(DaoSummoner(id="player-1", summoner_name="Alpha#EUW", games_played=3, games_won=2, kill=10, death=5, assist=8))
     db_session.add(Champion.create_default(id="Ahri", name="Ahri"))
+    db_session.add(Queue(queue_id=420, map="Summoner's Rift", description="Ranked Solo", notes=None))
     db_session.commit()
 
     matches = [
-        DaoMatch(id="match-1", created=100, ended=130, gametype="ranked", patch="14.5"),
-        DaoMatch(id="match-2", created=200, ended=230, gametype="ranked", patch="14.5"),
-        DaoMatch(id="match-3", created=300, ended=330, gametype="ranked", patch="14.5"),
+        DaoMatch(id="match-1", created=100, ended=130, queue_id=420, patch="14.5"),
+        DaoMatch(id="match-2", created=200, ended=230, queue_id=420, patch="14.5"),
+        DaoMatch(id="match-3", created=300, ended=330, queue_id=420, patch="14.5"),
     ]
     db_session.add_all(matches)
     db_session.add_all(
@@ -174,7 +178,8 @@ def test_summoner_lookups_are_case_insensitive(db_session):
     dao = DAO(db_session)
     db_session.add(DaoSummoner(id="player-1", summoner_name="Alpha#EUW", games_played=2, games_won=1, kill=7, death=3, assist=9))
     db_session.add(Champion.create_default(id="Ahri", name="Ahri"))
-    db_session.add(DaoMatch(id="match-1", created=100, ended=130, gametype="ranked", patch="14.5"))
+    db_session.add(Queue(queue_id=420, map="Summoner's Rift", description="Ranked Solo", notes=None))
+    db_session.add(DaoMatch(id="match-1", created=100, ended=130, queue_id=420, patch="14.5"))
     db_session.add(
         DaoMatchParticipant(
             summoner_id="player-1",
@@ -205,11 +210,12 @@ def test_summoner_lookups_are_case_insensitive(db_session):
 def test_get_champion_versions_returns_descending_order(db_session):
     dao = DAO(db_session)
     db_session.add(Champion(id="Ahri", champion_name="Ahri"))
+    db_session.add(Queue(queue_id=420, map="Summoner's Rift", description="Ranked Solo", notes=None))
     db_session.add_all(
         [
-            ChampionStats(champion_id="Ahri", patch="14.4", gametype="Ranked Solo", games_played=10, games_won=5, games_banned=1, kill=30, assist=20, death=10),
-            ChampionStats(champion_id="Ahri", patch="14.10", gametype="Ranked Solo", games_played=12, games_won=6, games_banned=2, kill=36, assist=24, death=12),
-            ChampionStats(champion_id="Ahri", patch="14.5", gametype="Ranked Solo", games_played=11, games_won=5, games_banned=1, kill=33, assist=22, death=11),
+            ChampionStats(champion_id="Ahri", patch="14.4", queue_id=420, games_played=10, games_won=5, games_banned=1, kill=30, assist=20, death=10),
+            ChampionStats(champion_id="Ahri", patch="14.10", queue_id=420, games_played=12, games_won=6, games_banned=2, kill=36, assist=24, death=12),
+            ChampionStats(champion_id="Ahri", patch="14.5", queue_id=420, games_played=11, games_won=5, games_banned=1, kill=33, assist=22, death=11),
         ]
     )
     db_session.commit()
@@ -224,10 +230,16 @@ def test_get_champion_without_patch_returns_all_versions(db_session):
     db_session.add(Champion(id="Ahri", champion_name="Ahri"))
     db_session.add_all(
         [
-            ChampionStats(champion_id="Ahri", patch="14.5", gametype="Ranked Solo", games_played=10, games_won=5, games_banned=1, kill=30, assist=20, death=10),
-            ChampionStats(champion_id="Ahri", patch="14.4", gametype="ARAM", games_played=7, games_won=4, games_banned=0, kill=18, assist=25, death=9),
-            MatchesAnalyzed(patch="14.5", gametype="Ranked Solo", count=100),
-            MatchesAnalyzed(patch="14.4", gametype="ARAM", count=70),
+            Queue(queue_id=420, map="Summoner's Rift", description="Ranked Solo", notes=None),
+            Queue(queue_id=450, map="Howling Abyss", description="ARAM", notes=None),
+        ]
+    )
+    db_session.add_all(
+        [
+            ChampionStats(champion_id="Ahri", patch="14.5", queue_id=420, games_played=10, games_won=5, games_banned=1, kill=30, assist=20, death=10),
+            ChampionStats(champion_id="Ahri", patch="14.4", queue_id=450, games_played=7, games_won=4, games_banned=0, kill=18, assist=25, death=9),
+            MatchesAnalyzed(patch="14.5", queue_id=420, count=100),
+            MatchesAnalyzed(patch="14.4", queue_id=450, count=70),
         ]
     )
     db_session.commit()
@@ -241,11 +253,12 @@ def test_get_champion_without_patch_returns_all_versions(db_session):
 def test_get_champion_rates_use_matches_analyzed(db_session):
     dao = DAO(db_session)
     db_session.add(Champion(id="Ahri", champion_name="Ahri"))
+    db_session.add(Queue(queue_id=420, map="Summoner's Rift", description="Ranked Solo", notes=None))
     db_session.add(
         ChampionStats(
             champion_id="Ahri",
             patch="14.5",
-            gametype="CLASSIC",
+            queue_id=420,
             games_played=20,
             games_won=10,
             games_banned=5,
@@ -254,7 +267,7 @@ def test_get_champion_rates_use_matches_analyzed(db_session):
             death=10,
         )
     )
-    db_session.add(MatchesAnalyzed(patch="14.5", gametype="CLASSIC", count=200))
+    db_session.add(MatchesAnalyzed(patch="14.5", queue_id=420, count=200))
     db_session.commit()
 
     champion = dao.get_champion("Ahri", ["14.5"])

--- a/tests/test_riot_parsers.py
+++ b/tests/test_riot_parsers.py
@@ -38,7 +38,7 @@ def test_match_parser_maps_match_and_participants():
             "gameStartTimestamp": 1710000000000,
             "gameEndTimestamp": 1710002100000,
             "gameVersion": "15.7.123.4567",
-            "gameMode": "CLASSIC",
+            "queueId": 420,
             "participants": [
                 {
                     "puuid": "player-puuid",
@@ -60,7 +60,7 @@ def test_match_parser_maps_match_and_participants():
 
     assert match.match_id == "EUW1_123456789"
     assert match.version == "15.7"
-    assert match.mode == "CLASSIC"
+    assert match.queueId == 420
     assert len(match.participants) == 1
     assert match.participants[0].name == "PlayerOne"
     assert match.participants[0].puuid == "player-puuid"
@@ -73,7 +73,7 @@ def test_match_parser_keeps_short_version_untouched():
             "gameStartTimestamp": 1710000000000,
             "gameEndTimestamp": 1710002100000,
             "gameVersion": "15.8",
-            "gameMode": "CLASSIC",
+            "queueId": 440,
             "participants": [],
         },
     }

--- a/tests/test_summoner_endpoint.py
+++ b/tests/test_summoner_endpoint.py
@@ -30,7 +30,8 @@ def make_match_page() -> MatchPage:
             start=__import__("datetime").datetime.now(),
             end=__import__("datetime").datetime.now(),
             version="14.5",
-            mode="Ranked Solo",
+            queueId=420,
+            queueDescription="Ranked Solo",
             participants=[],
         )
         for i in range(settings.matches_per_page)
@@ -75,6 +76,8 @@ def test_summoner_matches_ajax_response(monkeypatch):
     data = response.json()
     assert len(data["matches"]) == settings.matches_per_page
     assert data["nextOffset"] == settings.matches_per_page
+    assert data["matches"][0]["queueDescription"] == "Ranked Solo"
+    assert "queueId" not in data["matches"][0]
 
 
 def test_not_found_page_displays_searched_summoner():

--- a/tests/test_summoner_services.py
+++ b/tests/test_summoner_services.py
@@ -43,7 +43,8 @@ class MockDAO:
                 start=datetime.now(),
                 end=datetime.now(),
                 version="14.5",
-                mode="Ranked",
+                queueId=420,
+                queueDescription="Ranked Solo",
                 participants=[],
             )
             for i in range(5)
@@ -160,7 +161,8 @@ def test_get_matches_has_more_is_false_when_page_is_exactly_full():
                     start=datetime.now(),
                     end=datetime.now(),
                     version="14.5",
-                    mode="Ranked",
+                    queueId=420,
+                    queueDescription="Ranked Solo",
                     participants=[],
                 )
                 for i in range(20)
@@ -232,7 +234,7 @@ def test_get_matches_service_fetches_remote_only_when_cache_empty():
                 "gameStartTimestamp": 1710000000000,
                 "gameEndTimestamp": 1710001800000,
                 "gameVersion": "14.5",
-                "gameMode": "CLASSIC",
+                "queueId": 420,
                 "participants": [
                     {
                         "puuid": "remote-puuid",
@@ -308,7 +310,7 @@ def test_get_matches_service_skips_failed_remote_match_detail():
                 "gameStartTimestamp": 1710000000000,
                 "gameEndTimestamp": 1710001800000,
                 "gameVersion": "14.5",
-                "gameMode": "CLASSIC",
+                "queueId": 420,
                 "participants": [
                     {
                         "puuid": "remote-puuid",
@@ -415,7 +417,7 @@ def test_load_summoner_page_refreshes_summoner_after_remote_matches():
                 "gameStartTimestamp": 1710000000000,
                 "gameEndTimestamp": 1710001800000,
                 "gameVersion": "14.5",
-                "gameMode": "CLASSIC",
+                "queueId": 420,
                 "participants": [
                     {
                         "puuid": "remote-puuid",
@@ -545,7 +547,8 @@ def test_get_matches_service_does_not_fetch_remote_when_cache_exists():
                     start=datetime.now(),
                     end=datetime.now(),
                     version="14.5",
-                    mode="Ranked",
+                    queueId=420,
+                    queueDescription="Ranked Solo",
                     participants=[],
                 )
             ]
@@ -627,7 +630,7 @@ def test_refresh_summoner_matches_service_inserts_only_missing_matches():
                     "gameStartTimestamp": 1_700_000_000_000,
                     "gameEndTimestamp": 1_700_000_600_000,
                     "gameVersion": "14.5",
-                    "gameMode": "Ranked",
+                    "queueId": 420,
                     "participants": [],
                 },
             }
@@ -748,7 +751,7 @@ def test_refresh_summoner_matches_service_pages_past_first_batch_for_older_match
                     "gameStartTimestamp": 1_700_000_000_000,
                     "gameEndTimestamp": 1_700_000_600_000,
                     "gameVersion": "14.5",
-                    "gameMode": "Ranked",
+                    "queueId": 420,
                     "participants": [],
                 },
             }
@@ -807,7 +810,7 @@ def test_refresh_uses_snapshot_then_match_exists_for_candidates_only():
                     "gameStartTimestamp": 1_700_000_000_000,
                     "gameEndTimestamp": 1_700_000_600_000,
                     "gameVersion": "14.5",
-                    "gameMode": "Ranked",
+                    "queueId": 420,
                     "participants": [],
                 },
             }

--- a/tools/queues.json
+++ b/tools/queues.json
@@ -1,0 +1,596 @@
+[
+    {
+        "queueId": 0,
+        "map": "Custom games",
+        "description": null,
+        "notes": null
+    },
+    {
+        "queueId": 2,
+        "map": "Summoner's Rift",
+        "description": "5v5 Blind Pick games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 430"
+    },
+    {
+        "queueId": 4,
+        "map": "Summoner's Rift",
+        "description": "5v5 Ranked Solo games",
+        "notes": "Deprecated in favor of queueId 420"
+    },
+    {
+        "queueId": 6,
+        "map": "Summoner's Rift",
+        "description": "5v5 Ranked Premade games",
+        "notes": "Game mode deprecated"
+    },
+    {
+        "queueId": 7,
+        "map": "Summoner's Rift",
+        "description": "Co-op vs AI games",
+        "notes": "Deprecated in favor of queueId 32 and 33"
+    },
+    {
+        "queueId": 8,
+        "map": "Twisted Treeline",
+        "description": "3v3 Normal games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 460"
+    },
+    {
+        "queueId": 9,
+        "map": "Twisted Treeline",
+        "description": "3v3 Ranked Flex games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 470"
+    },
+    {
+        "queueId": 14,
+        "map": "Summoner's Rift",
+        "description": "5v5 Draft Pick games",
+        "notes": "Deprecated in favor of queueId 400"
+    },
+    {
+        "queueId": 16,
+        "map": "Crystal Scar",
+        "description": "5v5 Dominion Blind Pick games",
+        "notes": "Game mode deprecated"
+    },
+    {
+        "queueId": 17,
+        "map": "Crystal Scar",
+        "description": "5v5 Dominion Draft Pick games",
+        "notes": "Game mode deprecated"
+    },
+    {
+        "queueId": 25,
+        "map": "Crystal Scar",
+        "description": "Dominion Co-op vs AI games",
+        "notes": "Game mode deprecated"
+    },
+    {
+        "queueId": 31,
+        "map": "Summoner's Rift",
+        "description": "Co-op vs AI Intro Bot games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 830"
+    },
+    {
+        "queueId": 32,
+        "map": "Summoner's Rift",
+        "description": "Co-op vs AI Beginner Bot games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 840"
+    },
+    {
+        "queueId": 33,
+        "map": "Summoner's Rift",
+        "description": "Co-op vs AI Intermediate Bot games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 850"
+    },
+    {
+        "queueId": 41,
+        "map": "Twisted Treeline",
+        "description": "3v3 Ranked Team games",
+        "notes": "Game mode deprecated"
+    },
+    {
+        "queueId": 42,
+        "map": "Summoner's Rift",
+        "description": "5v5 Ranked Team games",
+        "notes": "Game mode deprecated"
+    },
+    {
+        "queueId": 52,
+        "map": "Twisted Treeline",
+        "description": "Co-op vs AI games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 800"
+    },
+    {
+        "queueId": 61,
+        "map": "Summoner's Rift",
+        "description": "5v5 Team Builder games",
+        "notes": "Game mode deprecated"
+    },
+    {
+        "queueId": 65,
+        "map": "Howling Abyss",
+        "description": "5v5 ARAM games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 450"
+    },
+    {
+        "queueId": 67,
+        "map": "Howling Abyss",
+        "description": "ARAM Co-op vs AI games",
+        "notes": "Game mode deprecated"
+    },
+    {
+        "queueId": 70,
+        "map": "Summoner's Rift",
+        "description": "One for All games",
+        "notes": "Deprecated in patch 8.6 in favor of queueId 1020"
+    },
+    {
+        "queueId": 72,
+        "map": "Howling Abyss",
+        "description": "1v1 Snowdown Showdown games",
+        "notes": null
+    },
+    {
+        "queueId": 73,
+        "map": "Howling Abyss",
+        "description": "2v2 Snowdown Showdown games",
+        "notes": null
+    },
+    {
+        "queueId": 75,
+        "map": "Summoner's Rift",
+        "description": "6v6 Hexakill games",
+        "notes": null
+    },
+    {
+        "queueId": 76,
+        "map": "Summoner's Rift",
+        "description": "Ultra Rapid Fire games",
+        "notes": null
+    },
+    {
+        "queueId": 78,
+        "map": "Howling Abyss",
+        "description": "One For All: Mirror Mode games",
+        "notes": null
+    },
+    {
+        "queueId": 83,
+        "map": "Summoner's Rift",
+        "description": "Co-op vs AI Ultra Rapid Fire games",
+        "notes": null
+    },
+    {
+        "queueId": 91,
+        "map": "Summoner's Rift",
+        "description": "Doom Bots Rank 1 games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 950"
+    },
+    {
+        "queueId": 92,
+        "map": "Summoner's Rift",
+        "description": "Doom Bots Rank 2 games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 950"
+    },
+    {
+        "queueId": 93,
+        "map": "Summoner's Rift",
+        "description": "Doom Bots Rank 5 games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 950"
+    },
+    {
+        "queueId": 96,
+        "map": "Crystal Scar",
+        "description": "Ascension games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 910"
+    },
+    {
+        "queueId": 98,
+        "map": "Twisted Treeline",
+        "description": "6v6 Hexakill games",
+        "notes": null
+    },
+    {
+        "queueId": 100,
+        "map": "Butcher's Bridge",
+        "description": "5v5 ARAM games",
+        "notes": null
+    },
+    {
+        "queueId": 300,
+        "map": "Howling Abyss",
+        "description": "Legend of the Poro King games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 920"
+    },
+    {
+        "queueId": 310,
+        "map": "Summoner's Rift",
+        "description": "Nemesis games",
+        "notes": null
+    },
+    {
+        "queueId": 313,
+        "map": "Summoner's Rift",
+        "description": "Black Market Brawlers games",
+        "notes": null
+    },
+    {
+        "queueId": 315,
+        "map": "Summoner's Rift",
+        "description": "Nexus Siege games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 940"
+    },
+    {
+        "queueId": 317,
+        "map": "Crystal Scar",
+        "description": "Definitely Not Dominion games",
+        "notes": null
+    },
+    {
+        "queueId": 318,
+        "map": "Summoner's Rift",
+        "description": "ARURF games",
+        "notes": "Deprecated in patch 7.19 in favor of queueId 900"
+    },
+    {
+        "queueId": 325,
+        "map": "Summoner's Rift",
+        "description": "All Random games",
+        "notes": null
+    },
+    {
+        "queueId": 400,
+        "map": "Summoner's Rift",
+        "description": "5v5 Draft Pick games",
+        "notes": null
+    },
+    {
+        "queueId": 410,
+        "map": "Summoner's Rift",
+        "description": "5v5 Ranked Dynamic games",
+        "notes": "Game mode deprecated in patch 6.22"
+    },
+    {
+        "queueId": 420,
+        "map": "Summoner's Rift",
+        "description": "5v5 Ranked Solo games",
+        "notes": null
+    },
+    {
+        "queueId": 430,
+        "map": "Summoner's Rift",
+        "description": "5v5 Blind Pick games",
+        "notes": null
+    },
+    {
+        "queueId": 440,
+        "map": "Summoner's Rift",
+        "description": "5v5 Ranked Flex games",
+        "notes": null
+    },
+    {
+        "queueId": 450,
+        "map": "Howling Abyss",
+        "description": "5v5 ARAM games",
+        "notes": null
+    },
+    {
+        "queueId": 460,
+        "map": "Twisted Treeline",
+        "description": "3v3 Blind Pick games",
+        "notes": "Deprecated in patch 9.23"
+    },
+    {
+        "queueId": 470,
+        "map": "Twisted Treeline",
+        "description": "3v3 Ranked Flex games",
+        "notes": "Deprecated in patch 9.23"
+    },
+    {
+        "queueId": 480,
+        "map": "Summoner's Rift",
+        "description": "Swiftplay Games",
+        "notes": null
+    },
+    {
+        "queueId": 490,
+        "map": "Summoner's Rift",
+        "description": "Normal (Quickplay)",
+        "notes": null
+    },
+    {
+        "queueId": 600,
+        "map": "Summoner's Rift",
+        "description": "Blood Hunt Assassin games",
+        "notes": null
+    },
+    {
+        "queueId": 610,
+        "map": "Cosmic Ruins",
+        "description": "Dark Star: Singularity games",
+        "notes": null
+    },
+    {
+        "queueId": 700,
+        "map": "Summoner's Rift",
+        "description": "Summoner's Rift Clash games",
+        "notes": null
+    },
+    {
+        "queueId": 720,
+        "map": "Howling Abyss",
+        "description": "ARAM Clash games",
+        "notes": null
+    },
+    {
+        "queueId": 800,
+        "map": "Twisted Treeline",
+        "description": "Co-op vs. AI Intermediate Bot games",
+        "notes": "Deprecated in patch 9.23"
+    },
+    {
+        "queueId": 810,
+        "map": "Twisted Treeline",
+        "description": "Co-op vs. AI Intro Bot games",
+        "notes": "Deprecated in patch 9.23"
+    },
+    {
+        "queueId": 820,
+        "map": "Twisted Treeline",
+        "description": "Co-op vs. AI Beginner Bot games",
+        "notes": null
+    },
+    {
+        "queueId": 830,
+        "map": "Summoner's Rift",
+        "description": "Co-op vs. AI Intro Bot games",
+        "notes": "Deprecated in March 2024 in favor of queueId 870"
+    },
+    {
+        "queueId": 840,
+        "map": "Summoner's Rift",
+        "description": "Co-op vs. AI Beginner Bot games",
+        "notes": "Deprecated in March 2024 in favor of queueId 880"
+    },
+    {
+        "queueId": 850,
+        "map": "Summoner's Rift",
+        "description": "Co-op vs. AI Intermediate Bot games",
+        "notes": "Deprecated in March 2024 in favor of queueId 890"
+    },
+    {
+        "queueId": 870,
+        "map": "Summoner's Rift",
+        "description": "Co-op vs. AI Intro Bot games",
+        "notes": null
+    },
+    {
+        "queueId": 880,
+        "map": "Summoner's Rift",
+        "description": "Co-op vs. AI Beginner Bot games",
+        "notes": null
+    },
+    {
+        "queueId": 890,
+        "map": "Summoner's Rift",
+        "description": "Co-op vs. AI Intermediate Bot games",
+        "notes": null
+    },
+    {
+        "queueId": 900,
+        "map": "Summoner's Rift",
+        "description": "ARURF games",
+        "notes": null
+    },
+    {
+        "queueId": 910,
+        "map": "Crystal Scar",
+        "description": "Ascension games",
+        "notes": null
+    },
+    {
+        "queueId": 920,
+        "map": "Howling Abyss",
+        "description": "Legend of the Poro King games",
+        "notes": null
+    },
+    {
+        "queueId": 940,
+        "map": "Summoner's Rift",
+        "description": "Nexus Siege games",
+        "notes": null
+    },
+    {
+        "queueId": 950,
+        "map": "Summoner's Rift",
+        "description": "Doom Bots Voting games",
+        "notes": null
+    },
+    {
+        "queueId": 960,
+        "map": "Summoner's Rift",
+        "description": "Doom Bots Standard games",
+        "notes": null
+    },
+    {
+        "queueId": 980,
+        "map": "Valoran City Park",
+        "description": "Star Guardian Invasion: Normal games",
+        "notes": null
+    },
+    {
+        "queueId": 990,
+        "map": "Valoran City Park",
+        "description": "Star Guardian Invasion: Onslaught games",
+        "notes": null
+    },
+    {
+        "queueId": 1000,
+        "map": "Overcharge",
+        "description": "PROJECT: Hunters games",
+        "notes": null
+    },
+    {
+        "queueId": 1010,
+        "map": "Summoner's Rift",
+        "description": "Snow ARURF games",
+        "notes": null
+    },
+    {
+        "queueId": 1020,
+        "map": "Summoner's Rift",
+        "description": "One for All games",
+        "notes": null
+    },
+    {
+        "queueId": 1030,
+        "map": "Crash Site",
+        "description": "Odyssey Extraction: Intro games",
+        "notes": null
+    },
+    {
+        "queueId": 1040,
+        "map": "Crash Site",
+        "description": "Odyssey Extraction: Cadet games",
+        "notes": null
+    },
+    {
+        "queueId": 1050,
+        "map": "Crash Site",
+        "description": "Odyssey Extraction: Crewmember games",
+        "notes": null
+    },
+    {
+        "queueId": 1060,
+        "map": "Crash Site",
+        "description": "Odyssey Extraction: Captain games",
+        "notes": null
+    },
+    {
+        "queueId": 1070,
+        "map": "Crash Site",
+        "description": "Odyssey Extraction: Onslaught games",
+        "notes": null
+    },
+    {
+        "queueId": 1090,
+        "map": "Convergence",
+        "description": "Teamfight Tactics games",
+        "notes": null
+    },
+    {
+        "queueId": 1100,
+        "map": "Convergence",
+        "description": "Ranked Teamfight Tactics games",
+        "notes": null
+    },
+    {
+        "queueId": 1110,
+        "map": "Convergence",
+        "description": "Teamfight Tactics Tutorial games",
+        "notes": null
+    },
+    {
+        "queueId": 1111,
+        "map": "Convergence",
+        "description": "Teamfight Tactics test games",
+        "notes": null
+    },
+    {
+        "queueId": 1200,
+        "map": "Nexus Blitz",
+        "description": "Nexus Blitz games",
+        "notes": "Deprecated in patch 9.2"
+    },
+    {
+        "queueId": 1210,
+        "map": "Convergence",
+        "description": "Teamfight Tactics Choncc's Treasure Mode",
+        "notes": "null"
+    },
+    {
+        "queueId": 1300,
+        "map": "Nexus Blitz",
+        "description": "Nexus Blitz games",
+        "notes": null
+    },
+    {
+        "queueId": 1400,
+        "map": "Summoner's Rift",
+        "description": "Ultimate Spellbook games",
+        "notes": null
+    },
+    {
+        "queueId": 1700,
+        "map": "Rings of Wrath",
+        "description": "Arena",
+        "notes": null
+    },
+    {
+        "queueId": 1710,
+        "map": "Rings of Wrath",
+        "description": "Arena",
+        "notes": "16 player lobby"
+    },
+    {
+        "queueId": 1810,
+        "map": "Swarm",
+        "description": "Swarm Mode Games",
+        "notes": "Swarm Mode 1 player"
+     },
+     {
+        "queueId": 1820,
+        "map": "Swarm Mode Games",
+        "description": "Swarm",
+        "notes": "Swarm Mode 2 players"
+     },
+     {
+        "queueId": 1830,
+        "map": "Swarm Mode Games",
+        "description": "Swarm",
+        "notes": "Swarm Mode 3 players"
+     },
+     {
+        "queueId": 1840,
+        "map": "Swarm Mode Games",
+        "description": "Swarm",
+        "notes": "Swarm Mode 4 players"
+     },
+    {
+        "queueId": 1900,
+        "map": "Summoner's Rift",
+        "description": "Pick URF games",
+        "notes": null
+    },
+    {
+        "queueId": 2000,
+        "map": "Summoner's Rift",
+        "description": "Tutorial 1",
+        "notes": null
+    },
+    {
+        "queueId": 2010,
+        "map": "Summoner's Rift",
+        "description": "Tutorial 2",
+        "notes": null
+    },
+    {
+        "queueId": 2020,
+        "map": "Summoner's Rift",
+        "description": "Tutorial 3",
+        "notes": null
+    },
+    {
+        "queueId": 2300,
+        "map": "The Bandlewood",
+        "description": "Brawl",
+        "notes": null
+    },
+    {
+        "queueId": 2400,
+        "map": "Howling Abyss",
+        "description": "ARAM: Mayhem",
+        "notes": null
+    }
+]


### PR DESCRIPTION
Gamemode types were replaced by queue types throughout the app. Normal queues and ranked queues are now distinguishable.

Queue types were incorporated into summoner's page and champion page in the place of gamemode types.