### PR TITLE
Added queue filter and KDA to favorite champions

### DIFF
--- a/alembic/versions/9a4b6c7d8e90_summoner_champion_queue_and_kda.py
+++ b/alembic/versions/9a4b6c7d8e90_summoner_champion_queue_and_kda.py
@@ -1,0 +1,183 @@
+"""add queue and kda totals to summoner champion
+
+Revision ID: 9a4b6c7d8e90
+Revises: c2f4a8d01f11
+Create Date: 2026-05-03 23:50:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "9a4b6c7d8e90"
+down_revision: Union[str, Sequence[str], None] = "c2f4a8d01f11"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS Summoner_champion_trigger ON match_participant")
+
+    op.drop_index(op.f("ix_summoner_champion_champion_id"), table_name="summoner_champion")
+    op.drop_index(op.f("ix_summoner_champion_summoner_id"), table_name="summoner_champion")
+    op.drop_table("summoner_champion")
+
+    op.create_table(
+        "summoner_champion",
+        sa.Column("summoner_id", sa.String(), nullable=False),
+        sa.Column("champion_id", sa.String(), nullable=False),
+        sa.Column("queue_id", sa.Integer(), nullable=False),
+        sa.Column("games_played", sa.Integer(), nullable=True),
+        sa.Column("games_won", sa.Integer(), nullable=True),
+        sa.Column("kill", sa.Integer(), nullable=True),
+        sa.Column("death", sa.Integer(), nullable=True),
+        sa.Column("assist", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["champion_id"], ["champion.id"]),
+        sa.ForeignKeyConstraint(["queue_id"], ["queues.queue_id"]),
+        sa.ForeignKeyConstraint(["summoner_id"], ["summoner.id"]),
+        sa.PrimaryKeyConstraint("summoner_id", "champion_id", "queue_id"),
+    )
+    op.create_index(op.f("ix_summoner_champion_champion_id"), "summoner_champion", ["champion_id"], unique=False)
+    op.create_index(op.f("ix_summoner_champion_queue_id"), "summoner_champion", ["queue_id"], unique=False)
+    op.create_index(op.f("ix_summoner_champion_summoner_id"), "summoner_champion", ["summoner_id"], unique=False)
+
+    op.execute(
+        """
+        INSERT INTO summoner_champion (
+            summoner_id,
+            champion_id,
+            queue_id,
+            games_played,
+            games_won,
+            kill,
+            death,
+            assist
+        )
+        SELECT
+            mp.summoner_id,
+            mp.champion,
+            m.queue_id,
+            COUNT(*) AS games_played,
+            SUM(CASE WHEN mp.won THEN 1 ELSE 0 END) AS games_won,
+            SUM(mp.kill) AS kill,
+            SUM(mp.death) AS death,
+            SUM(mp.assist) AS assist
+        FROM match_participant mp
+        JOIN "match" m ON m.id = mp.match_id
+        WHERE m.queue_id IS NOT NULL
+        GROUP BY mp.summoner_id, mp.champion, m.queue_id;
+
+        CREATE OR REPLACE FUNCTION increment_summoner_champion()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            INSERT INTO summoner_champion (
+                summoner_id,
+                champion_id,
+                queue_id,
+                games_played,
+                games_won,
+                kill,
+                death,
+                assist
+            )
+            SELECT
+                NEW.summoner_id,
+                NEW.champion,
+                m.queue_id,
+                1,
+                CASE WHEN NEW.won THEN 1 ELSE 0 END,
+                NEW.kill,
+                NEW.death,
+                NEW.assist
+            FROM "match" m
+            WHERE m.id = NEW.match_id
+              AND m.queue_id IS NOT NULL
+            ON CONFLICT (summoner_id, champion_id, queue_id)
+            DO UPDATE
+            SET
+                games_played = summoner_champion.games_played + 1,
+                games_won = COALESCE(summoner_champion.games_won, 0) +
+                    CASE WHEN NEW.won THEN 1 ELSE 0 END,
+                kill = summoner_champion.kill + NEW.kill,
+                death = summoner_champion.death + NEW.death,
+                assist = summoner_champion.assist + NEW.assist;
+
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+
+        CREATE TRIGGER Summoner_champion_trigger
+            AFTER INSERT
+            ON match_participant
+            FOR EACH ROW
+            EXECUTE FUNCTION increment_summoner_champion();
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS Summoner_champion_trigger ON match_participant")
+
+    op.drop_index(op.f("ix_summoner_champion_summoner_id"), table_name="summoner_champion")
+    op.drop_index(op.f("ix_summoner_champion_queue_id"), table_name="summoner_champion")
+    op.drop_index(op.f("ix_summoner_champion_champion_id"), table_name="summoner_champion")
+    op.drop_table("summoner_champion")
+
+    op.create_table(
+        "summoner_champion",
+        sa.Column("summoner_id", sa.String(), nullable=False),
+        sa.Column("champion_id", sa.String(), nullable=False),
+        sa.Column("games_played", sa.Integer(), nullable=True),
+        sa.Column("games_won", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["champion_id"], ["champion.id"]),
+        sa.ForeignKeyConstraint(["summoner_id"], ["summoner.id"]),
+        sa.PrimaryKeyConstraint("summoner_id", "champion_id"),
+    )
+    op.create_index(op.f("ix_summoner_champion_champion_id"), "summoner_champion", ["champion_id"], unique=False)
+    op.create_index(op.f("ix_summoner_champion_summoner_id"), "summoner_champion", ["summoner_id"], unique=False)
+
+    op.execute(
+        """
+        INSERT INTO summoner_champion (
+            summoner_id,
+            champion_id,
+            games_played,
+            games_won
+        )
+        SELECT
+            mp.summoner_id,
+            mp.champion,
+            COUNT(*) AS games_played,
+            SUM(CASE WHEN mp.won THEN 1 ELSE 0 END) AS games_won
+        FROM match_participant mp
+        GROUP BY mp.summoner_id, mp.champion;
+
+        CREATE OR REPLACE FUNCTION increment_summoner_champion()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            INSERT INTO summoner_champion (summoner_id, champion_id, games_played, games_won)
+            SELECT
+                NEW.summoner_id,
+                NEW.champion,
+                1,
+                CASE WHEN NEW.won THEN 1 ELSE 0 END
+            ON CONFLICT (summoner_id, champion_id)
+            DO UPDATE
+            SET
+                games_played = summoner_champion.games_played + 1,
+                games_won = COALESCE(summoner_champion.games_won, 0) +
+                    CASE WHEN NEW.won THEN 1 ELSE 0 END;
+
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+
+        CREATE TRIGGER Summoner_champion_trigger
+            AFTER INSERT
+            ON match_participant
+            FOR EACH ROW
+            EXECUTE FUNCTION increment_summoner_champion();
+        """
+    )

--- a/app/api/config.py
+++ b/app/api/config.py
@@ -8,7 +8,7 @@ class Settings(BaseSettings):
 	summoner_sync_stop_after: int = Field(default=20, ge=1)
 	periodic_sync_stop_after: int = Field(default=1, ge=1)
 	default_champion_version: str = Field(default="14.5", min_length=1)
-	favorite_champion_count:int = Field(default=3, ge=1)
+	favorite_champion_page_size:int = Field(default=5, ge=1)
 	otel_enabled: bool = Field(default=True)
 	otel_service_name: str = Field(default="psi-api", min_length=1)
 	otel_service_version: str = Field(default="0.1.0", min_length=1)

--- a/app/database/DAO.py
+++ b/app/database/DAO.py
@@ -631,6 +631,7 @@ class DAO:
         summoner_id,
         count,
         queue_filter: str = QUEUE_FILTER_ALL,
+        offset: int = 0,
     ) -> list[app.models.summonerModels.SummonerChampion]:
         result = []
         favorite_query = (
@@ -646,7 +647,12 @@ class DAO:
         )
         db_favorite_champions = (
             favorite_query
-            .order_by(SummonerChampion.games_played.desc())
+            .order_by(
+                SummonerChampion.games_played.desc(),
+                Champion.champion_name.asc(),
+                SummonerChampion.queue_id.asc(),
+            )
+            .offset(offset)
             .limit(count)
             .all()
         )

--- a/app/database/DAO.py
+++ b/app/database/DAO.py
@@ -178,6 +178,10 @@ class DAO:
 
     @staticmethod
     def _apply_queue_filter_to_match_query(query, queue_filter: str):
+        return DAO._apply_queue_filter_to_column(query, Match.queue_id, queue_filter)
+
+    @staticmethod
+    def _apply_queue_filter_to_column(query, queue_id_column, queue_filter: str):
         normalized = normalize_queue_filter(queue_filter)
 
         if normalized == QUEUE_FILTER_ALL:
@@ -186,8 +190,8 @@ class DAO:
         if normalized == QUEUE_FILTER_OTHER:
             return query.filter(
                 or_(
-                    Match.queue_id.is_(None),
-                    Match.queue_id.notin_(PRIMARY_QUEUE_IDS),
+                    queue_id_column.is_(None),
+                    queue_id_column.notin_(PRIMARY_QUEUE_IDS),
                 )
             )
 
@@ -195,7 +199,7 @@ class DAO:
         if queue_id is None:
             return query
 
-        return query.filter(Match.queue_id == queue_id)
+        return query.filter(queue_id_column == queue_id)
 
     def get_champion_versions(self, champion_name: str) -> list[str]:
         versions = (
@@ -622,20 +626,41 @@ class DAO:
     def get_item_dao(self, item_id: int) -> Item | None:
         return self.db.query(Item).filter(Item.item_id == item_id).first()
 
-    def get_summoner_champions(self,summoner_id,count) -> list[app.models.summonerModels.SummonerChampion]:
+    def get_summoner_champions(
+        self,
+        summoner_id,
+        count,
+        queue_filter: str = QUEUE_FILTER_ALL,
+    ) -> list[app.models.summonerModels.SummonerChampion]:
         result = []
-        db_favorite_champions = (self.db.query(SummonerChampion)
-                                 .join(Champion)
-                                 #.filter(Champion.id == SummonerChampion.champion_id)
-                                 .filter(SummonerChampion.summoner_id == summoner_id)
-                                 .order_by(SummonerChampion.games_played.desc()).
-                                 limit(count).all())
+        favorite_query = (
+            self.db.query(SummonerChampion)
+            .join(Champion)
+            #.filter(Champion.id == SummonerChampion.champion_id)
+            .filter(SummonerChampion.summoner_id == summoner_id)
+        )
+        favorite_query = self._apply_queue_filter_to_column(
+            favorite_query,
+            SummonerChampion.queue_id,
+            queue_filter,
+        )
+        db_favorite_champions = (
+            favorite_query
+            .order_by(SummonerChampion.games_played.desc())
+            .limit(count)
+            .all()
+        )
         for champion in db_favorite_champions:
             result.append(app.models.summonerModels.SummonerChampion(
                 games_played=champion.games_played,
                 wins=champion.games_won,
                 champion_id=champion.champion_id,
+                queueId=champion.queue_id,
+                queueDescription=self._get_queue_description(champion.SummonerChampion_Queue, champion.queue_id),
                 champion_name=champion.SummonerChampion_Champion.champion_name,
+                kills=champion.kill or 0,
+                deaths=champion.death or 0,
+                assists=champion.assist or 0,
             ))
         return result
 

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -104,6 +104,7 @@ class Queue(Base):
     Queue_MatchesAnalyzed= relationship("MatchesAnalyzed", back_populates="MatchesAnalyzed_Queue")
     Queue_Match = relationship("Match", back_populates="Match_Queue")
     Queue_SummonerQueue = relationship("SummonerQueue", back_populates="SummonerQueue_Queue")
+    Queue_SummonerChampion = relationship("SummonerChampion", back_populates="SummonerChampion_Queue")
 
 
 class Item(Base):
@@ -136,11 +137,16 @@ class SummonerChampion(Base):
     __tablename__ = "summoner_champion"
     summoner_id = Column(String,ForeignKey("summoner.id"), primary_key=True, index=True)
     champion_id = Column(String,ForeignKey("champion.id"), primary_key=True, index=True)
+    queue_id = Column(Integer, ForeignKey("queues.queue_id"), primary_key=True, index=True)
     games_played = Column(Integer)
     games_won = Column(Integer)
+    kill = Column(Integer)
+    death = Column(Integer)
+    assist = Column(Integer)
 
     SummonerChampion_Champion = relationship("Champion", back_populates="Champion_SummonerChampion")
     SummonerChampion_Summoner = relationship("Summoner", back_populates="Summoner_SummonerChampion")
+    SummonerChampion_Queue = relationship("Queue", back_populates="Queue_SummonerChampion")
 
 class MatchesAnalyzed(Base):
     __tablename__ = "matches_analyzed"

--- a/app/endpoints/endpoints.py
+++ b/app/endpoints/endpoints.py
@@ -24,7 +24,7 @@ from app.services.championServices import (
 )
 from app.utils.champion_kit import resolve_champion_kit
 from app.utils.champion_assets import resolve_champion_image_path
-from app.utils.queue_filters import QUEUE_FILTER_OPTIONS, normalize_queue_filter
+from app.utils.queue_filters import QUEUE_FILTER_OPTIONS, FAVORITE_QUEUE_FILTER_OPTIONS, normalize_queue_filter, normalize_favorite_queue_filter
 from app.utils.versioning import normalize_version
 from app.telemetry.metrics import get_riot_ingestion_status
 
@@ -100,7 +100,9 @@ async def get_summoner(
     tagline: str,
     offset: int = 0,
     ajax: bool = False,
-    queue_filter: str = "all",
+    match_queue_filter: str | None = None,
+    favorite_queue_filter: str | None = None,
+    queue_filter: str | None = None,
     dao: DAO = Depends(get_dao),
 ):
     logger.info(
@@ -114,9 +116,10 @@ async def get_summoner(
     )
 
     count = settings.matches_per_page
-    selected_queue_filter = normalize_queue_filter(queue_filter)
+    selected_match_queue_filter = normalize_queue_filter(match_queue_filter or queue_filter)
+    selected_favorite_queue_filter = normalize_favorite_queue_filter(favorite_queue_filter or queue_filter)
 
-    page_data = load_summoner_page(request, name, tagline, offset, count, dao, selected_queue_filter)
+    page_data = load_summoner_page(request, name, tagline, offset, count, dao, selected_match_queue_filter)
     summoner = page_data.summoner
 
     if summoner is None:
@@ -132,7 +135,7 @@ async def get_summoner(
         dao,
         0,
         settings.favorite_champion_page_size,
-        selected_queue_filter,
+        selected_favorite_queue_filter,
     )
     match_page = page_data.match_page
 
@@ -147,8 +150,10 @@ async def get_summoner(
             "matchData": match_page,
             "favoriteChampionData": favorite_champion_page,
             "favoriteChampios":favorite_champion_page.champions,
-            "queue_filter": selected_queue_filter,
-            "queue_filters": QUEUE_FILTER_OPTIONS,
+            "match_queue_filter": selected_match_queue_filter,
+            "favorite_queue_filter": selected_favorite_queue_filter,
+            "match_queue_filters": QUEUE_FILTER_OPTIONS,
+            "favorite_queue_filters": FAVORITE_QUEUE_FILTER_OPTIONS,
         },
     )
 
@@ -159,10 +164,11 @@ async def get_summoner_favorite_champions(
     name: str,
     tagline: str,
     offset: int = 0,
-    queue_filter: str = "all",
+    favorite_queue_filter: str | None = None,
+    queue_filter: str | None = None,
     dao: DAO = Depends(get_dao),
 ):
-    selected_queue_filter = normalize_queue_filter(queue_filter)
+    selected_favorite_queue_filter = normalize_favorite_queue_filter(favorite_queue_filter or queue_filter)
     summoner = get_summoner_service(request, name, tagline, dao)
 
     if summoner is None:
@@ -173,7 +179,7 @@ async def get_summoner_favorite_champions(
         dao,
         offset,
         settings.favorite_champion_page_size,
-        selected_queue_filter,
+        selected_favorite_queue_filter,
     )
     return JSONResponse(content=jsonable_encoder(favorite_champion_page))
 

--- a/app/endpoints/endpoints.py
+++ b/app/endpoints/endpoints.py
@@ -9,7 +9,12 @@ from app.api.config import settings
 
 from app.database.DAO import DAO
 
-from app.services.summonerServices import load_summoner_page, refresh_summoner_matches_service, load_favorite_champions
+from app.services.summonerServices import (
+    get_summoner_service,
+    load_summoner_page,
+    refresh_summoner_matches_service,
+    load_favorite_champion_page,
+)
 from app.services.championServices import (
     aggregate_stats_for_version,
     build_trend_series,
@@ -122,10 +127,11 @@ async def get_summoner(
             ),
             status_code=303
         )
-    favorite_champion = load_favorite_champions(
+    favorite_champion_page = load_favorite_champion_page(
         summoner.puuid,
         dao,
-        settings.favorite_champion_count,
+        0,
+        settings.favorite_champion_page_size,
         selected_queue_filter,
     )
     match_page = page_data.match_page
@@ -139,11 +145,37 @@ async def get_summoner(
         context={
             "summoner": summoner,
             "matchData": match_page,
-            "favoriteChampios":favorite_champion,
+            "favoriteChampionData": favorite_champion_page,
+            "favoriteChampios":favorite_champion_page.champions,
             "queue_filter": selected_queue_filter,
             "queue_filters": QUEUE_FILTER_OPTIONS,
         },
     )
+
+
+@router.get("/summoner/{name}/{tagline}/favorite-champions")
+async def get_summoner_favorite_champions(
+    request: Request,
+    name: str,
+    tagline: str,
+    offset: int = 0,
+    queue_filter: str = "all",
+    dao: DAO = Depends(get_dao),
+):
+    selected_queue_filter = normalize_queue_filter(queue_filter)
+    summoner = get_summoner_service(request, name, tagline, dao)
+
+    if summoner is None:
+        raise HTTPException(status_code=404, detail="Summoner not found")
+
+    favorite_champion_page = load_favorite_champion_page(
+        summoner.puuid,
+        dao,
+        offset,
+        settings.favorite_champion_page_size,
+        selected_queue_filter,
+    )
+    return JSONResponse(content=jsonable_encoder(favorite_champion_page))
 
 
 @router.post("/summoner/{name}/{tagline}/refresh")

--- a/app/endpoints/endpoints.py
+++ b/app/endpoints/endpoints.py
@@ -122,7 +122,12 @@ async def get_summoner(
             ),
             status_code=303
         )
-    favorite_champion = load_favorite_champions(summoner.puuid,dao,settings.favorite_champion_count)
+    favorite_champion = load_favorite_champions(
+        summoner.puuid,
+        dao,
+        settings.favorite_champion_count,
+        selected_queue_filter,
+    )
     match_page = page_data.match_page
 
     if ajax:

--- a/app/models/summonerModels.py
+++ b/app/models/summonerModels.py
@@ -91,12 +91,21 @@ class SummonerData(BaseModel):
 class SummonerChampion(BaseModel):
     champion_name: str
     champion_id: str
+    queueId: int = Field(default=0, exclude=True)
+    queueDescription: str = ""
     games_played: int
     wins: int
+    kills: int = 0
+    deaths: int = 0
+    assists: int = 0
 
     @property
     def winrate(self):
         return (self.wins / self.games_played) * 100 if self.games_played else -1
+
+    @property
+    def kda(self):
+        return (self.kills + self.assists) / (self.deaths or 1)
 
 
 class SummonerDivision(BaseModel):

--- a/app/models/summonerModels.py
+++ b/app/models/summonerModels.py
@@ -108,6 +108,12 @@ class SummonerChampion(BaseModel):
         return (self.kills + self.assists) / (self.deaths or 1)
 
 
+class SummonerChampionPage(BaseModel):
+    champions: List[SummonerChampion]
+    hasMore: bool
+    nextOffset: int
+
+
 class SummonerDivision(BaseModel):
     queueId: int = Field(default=0, exclude=True)
     queueDescription: str

--- a/app/services/summonerServices.py
+++ b/app/services/summonerServices.py
@@ -4,7 +4,7 @@ from typing import NamedTuple, Optional
 import httpx
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
-from app.models.summonerModels import Summoner, MatchPage
+from app.models.summonerModels import Summoner, MatchPage, SummonerChampionPage
 from app.database.DAO import DAO
 from app.riot.riotParsers import (
     MatchParser,
@@ -289,10 +289,31 @@ def get_matches_service(
             refreshed_from_remote=refreshed_from_remote,
         )
 
-def load_favorite_champions(summoner_id,dao,count, queue_filter: str = QUEUE_FILTER_ALL):
+def load_favorite_champion_page(
+    summoner_id,
+    dao,
+    offset: int,
+    count: int,
+    queue_filter: str = QUEUE_FILTER_ALL,
+) -> SummonerChampionPage:
     normalized_queue_filter = normalize_queue_filter(queue_filter)
-    favorite_champions = dao.get_summoner_champions(summoner_id,count, normalized_queue_filter)
-    return favorite_champions
+    query_count = count + 1
+    favorite_champions = dao.get_summoner_champions(
+        summoner_id,
+        query_count,
+        normalized_queue_filter,
+        offset,
+    )
+    has_more = len(favorite_champions) > count
+    return SummonerChampionPage(
+        champions=favorite_champions[:count],
+        hasMore=has_more,
+        nextOffset=offset + count,
+    )
+
+
+def load_favorite_champions(summoner_id,dao,count, queue_filter: str = QUEUE_FILTER_ALL):
+    return load_favorite_champion_page(summoner_id, dao, 0, count, queue_filter).champions
 
 
 def load_summoner_page(

--- a/app/services/summonerServices.py
+++ b/app/services/summonerServices.py
@@ -289,8 +289,9 @@ def get_matches_service(
             refreshed_from_remote=refreshed_from_remote,
         )
 
-def load_favorite_champions(summoner_id,dao,count):
-    favorite_champions = dao.get_summoner_champions(summoner_id,count)
+def load_favorite_champions(summoner_id,dao,count, queue_filter: str = QUEUE_FILTER_ALL):
+    normalized_queue_filter = normalize_queue_filter(queue_filter)
+    favorite_champions = dao.get_summoner_champions(summoner_id,count, normalized_queue_filter)
     return favorite_champions
 
 

--- a/app/static/js/summoner.js
+++ b/app/static/js/summoner.js
@@ -12,7 +12,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const matchList = document.getElementById("match-list");
     const refreshButton = document.getElementById("refresh-matches");
     const refreshStatus = document.getElementById("refresh-status");
-    const queueFilterSelect = document.getElementById("queue-filter");
+    const queueFilterSelects = document.querySelectorAll("[data-queue-filter-select]");
     const loadedGamesValue = document.getElementById("loaded-games");
     const loadedWinrateValue = document.getElementById("loaded-winrate");
     const loadedKdaValue = document.getElementById("loaded-kda");
@@ -156,11 +156,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
     updateLoadedMatchSummary();
 
-    if (queueFilterSelect) {
+    queueFilterSelects.forEach((queueFilterSelect) => {
         queueFilterSelect.addEventListener("change", () => {
             window.location.assign(buildSummonerUrl(0, false, queueFilterSelect.value));
         });
-    }
+    });
 
     const loadMoreButton = document.getElementById("load-more");
 
@@ -276,4 +276,5 @@ document.addEventListener("DOMContentLoaded", () => {
             updateLoadedMatchSummary();
         });
     }
+
 });

--- a/app/static/js/summoner.js
+++ b/app/static/js/summoner.js
@@ -5,11 +5,13 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     let offset = Number(page.dataset.nextOffset);
+    let favoriteOffset = Number(page.dataset.favoriteNextOffset);
     const name = page.dataset.name;
     const tagline = page.dataset.tagline;
     const puuid = page.dataset.puuid;
     const queueFilter = page.dataset.queueFilter || "all";
     const matchList = document.getElementById("match-list");
+    const favoriteChampionList = document.getElementById("favorite-champion-list");
     const refreshButton = document.getElementById("refresh-matches");
     const refreshStatus = document.getElementById("refresh-status");
     const queueFilterSelects = document.querySelectorAll("[data-queue-filter-select]");
@@ -36,6 +38,20 @@ document.addEventListener("DOMContentLoaded", () => {
         }
 
         return `/summoner/${encodeURIComponent(name)}/${encodeURIComponent(tagline)}?${query}`;
+    }
+
+    function buildFavoriteChampionsUrl(baseOffset = 0, selectedQueueFilter = queueFilter) {
+        const params = new URLSearchParams();
+        if (baseOffset > 0) {
+            params.set("offset", String(baseOffset));
+        }
+        if (selectedQueueFilter && selectedQueueFilter !== "all") {
+            params.set("queue_filter", selectedQueueFilter);
+        }
+
+        const query = params.toString();
+        const baseUrl = `/summoner/${encodeURIComponent(name)}/${encodeURIComponent(tagline)}/favorite-champions`;
+        return query ? `${baseUrl}?${query}` : baseUrl;
     }
 
     function setRefreshStatus(message) {
@@ -89,6 +105,25 @@ document.addEventListener("DOMContentLoaded", () => {
                 : ``;
             return `<span class="${classes}" data-item-id="${itemId}" data-item-name="${itemName}" data-item-description="${itemDescription}" data-item-slot="${itemSlot}">${imageHtml}</span>`;
         }).join("")}</div>`;
+    }
+
+    function buildFavoriteChampionRowHtml(favorite) {
+        const gamesPlayed = readNumber(favorite.games_played);
+        const wins = readNumber(favorite.wins);
+        const kills = readNumber(favorite.kills);
+        const deaths = readNumber(favorite.deaths);
+        const assists = readNumber(favorite.assists);
+        const winrate = gamesPlayed > 0 ? (wins / gamesPlayed) * 100 : -1;
+        const kda = (kills + assists) / Math.max(1, deaths);
+
+        return `<tr>
+            <td>${escapeHtml(favorite.champion_name)}</td>
+            <td>${escapeHtml(favorite.queueDescription)}</td>
+            <td>${gamesPlayed}</td>
+            <td>${wins}</td>
+            <td>${formatDecimal(winrate)}%</td>
+            <td>${formatDecimal(kda)}</td>
+        </tr>`;
     }
 
     function updateLoadedMatchSummary() {
@@ -163,6 +198,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     const loadMoreButton = document.getElementById("load-more");
+    const loadMoreFavoritesButton = document.getElementById("load-more-favorites");
 
     if (refreshButton) {
         refreshButton.addEventListener("click", async () => {
@@ -274,6 +310,26 @@ document.addEventListener("DOMContentLoaded", () => {
             }
 
             updateLoadedMatchSummary();
+        });
+    }
+
+    if (loadMoreFavoritesButton) {
+        loadMoreFavoritesButton.addEventListener("click", async () => {
+            loadMoreFavoritesButton.disabled = true;
+            const response = await fetch(buildFavoriteChampionsUrl(favoriteOffset, queueFilter));
+            const data = await response.json();
+
+            data.champions.forEach((favorite) => {
+                favoriteChampionList.insertAdjacentHTML("beforeend", buildFavoriteChampionRowHtml(favorite));
+            });
+
+            favoriteOffset = data.nextOffset;
+
+            if (!data.hasMore) {
+                loadMoreFavoritesButton.style.display = "none";
+            } else {
+                loadMoreFavoritesButton.disabled = false;
+            }
         });
     }
 

--- a/app/static/js/summoner.js
+++ b/app/static/js/summoner.js
@@ -9,18 +9,25 @@ document.addEventListener("DOMContentLoaded", () => {
     const name = page.dataset.name;
     const tagline = page.dataset.tagline;
     const puuid = page.dataset.puuid;
-    const queueFilter = page.dataset.queueFilter || "all";
+    const matchQueueFilter = page.dataset.matchQueueFilter || "all";
+    const favoriteQueueFilter = page.dataset.favoriteQueueFilter || "ranked_solo";
     const matchList = document.getElementById("match-list");
     const favoriteChampionList = document.getElementById("favorite-champion-list");
     const refreshButton = document.getElementById("refresh-matches");
     const refreshStatus = document.getElementById("refresh-status");
-    const queueFilterSelects = document.querySelectorAll("[data-queue-filter-select]");
+    const matchQueueFilterSelect = document.getElementById("match-queue-filter");
+    const favoriteQueueFilterSelect = document.getElementById("favorite-queue-filter");
     const loadedGamesValue = document.getElementById("loaded-games");
     const loadedWinrateValue = document.getElementById("loaded-winrate");
     const loadedKdaValue = document.getElementById("loaded-kda");
     const refreshMessageStorageKey = `summoner-refresh:${name}#${tagline}`;
 
-    function buildSummonerUrl(baseOffset = 0, ajax = false, selectedQueueFilter = queueFilter) {
+    function buildSummonerUrl(
+        baseOffset = 0,
+        ajax = false,
+        selectedMatchQueueFilter = matchQueueFilter,
+        selectedFavoriteQueueFilter = favoriteQueueFilter
+    ) {
         const params = new URLSearchParams();
         if (baseOffset > 0) {
             params.set("offset", String(baseOffset));
@@ -28,8 +35,11 @@ document.addEventListener("DOMContentLoaded", () => {
         if (ajax) {
             params.set("ajax", "true");
         }
-        if (selectedQueueFilter && selectedQueueFilter !== "all") {
-            params.set("queue_filter", selectedQueueFilter);
+        if (selectedMatchQueueFilter) {
+            params.set("match_queue_filter", selectedMatchQueueFilter);
+        }
+        if (selectedFavoriteQueueFilter) {
+            params.set("favorite_queue_filter", selectedFavoriteQueueFilter);
         }
 
         const query = params.toString();
@@ -40,13 +50,13 @@ document.addEventListener("DOMContentLoaded", () => {
         return `/summoner/${encodeURIComponent(name)}/${encodeURIComponent(tagline)}?${query}`;
     }
 
-    function buildFavoriteChampionsUrl(baseOffset = 0, selectedQueueFilter = queueFilter) {
+    function buildFavoriteChampionsUrl(baseOffset = 0, selectedFavoriteQueueFilter = favoriteQueueFilter) {
         const params = new URLSearchParams();
         if (baseOffset > 0) {
             params.set("offset", String(baseOffset));
         }
-        if (selectedQueueFilter && selectedQueueFilter !== "all") {
-            params.set("queue_filter", selectedQueueFilter);
+        if (selectedFavoriteQueueFilter) {
+            params.set("favorite_queue_filter", selectedFavoriteQueueFilter);
         }
 
         const query = params.toString();
@@ -191,11 +201,17 @@ document.addEventListener("DOMContentLoaded", () => {
 
     updateLoadedMatchSummary();
 
-    queueFilterSelects.forEach((queueFilterSelect) => {
-        queueFilterSelect.addEventListener("change", () => {
-            window.location.assign(buildSummonerUrl(0, false, queueFilterSelect.value));
+    if (matchQueueFilterSelect) {
+        matchQueueFilterSelect.addEventListener("change", () => {
+            window.location.assign(buildSummonerUrl(0, false, matchQueueFilterSelect.value, favoriteQueueFilter));
         });
-    });
+    }
+
+    if (favoriteQueueFilterSelect) {
+        favoriteQueueFilterSelect.addEventListener("change", () => {
+            window.location.assign(buildSummonerUrl(0, false, matchQueueFilter, favoriteQueueFilterSelect.value));
+        });
+    }
 
     const loadMoreButton = document.getElementById("load-more");
     const loadMoreFavoritesButton = document.getElementById("load-more-favorites");
@@ -224,7 +240,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 const refreshedRefreshMessageStorageKey = `summoner-refresh:${refreshedName}#${refreshedTagline}`;
                 if (data.insertedCount > 0 || summonerRouteChanged) {
                     sessionStorage.setItem(refreshedRefreshMessageStorageKey, refreshMessage);
-                    const refreshedUrl = new URL(buildSummonerUrl(0, false, queueFilter), window.location.origin);
+                    const refreshedUrl = new URL(buildSummonerUrl(0, false, matchQueueFilter, favoriteQueueFilter), window.location.origin);
                     refreshedUrl.pathname = `/summoner/${encodeURIComponent(refreshedName)}/${encodeURIComponent(refreshedTagline)}`;
                     window.location.assign(refreshedUrl.pathname + refreshedUrl.search);
                     return;
@@ -243,7 +259,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (loadMoreButton) {
         loadMoreButton.addEventListener("click", async () => {
-            const response = await fetch(buildSummonerUrl(offset, true, queueFilter));
+            const response = await fetch(buildSummonerUrl(offset, true, matchQueueFilter, favoriteQueueFilter));
             const data = await response.json();
 
             data.matches.forEach((match) => {
@@ -316,7 +332,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (loadMoreFavoritesButton) {
         loadMoreFavoritesButton.addEventListener("click", async () => {
             loadMoreFavoritesButton.disabled = true;
-            const response = await fetch(buildFavoriteChampionsUrl(favoriteOffset, queueFilter));
+            const response = await fetch(buildFavoriteChampionsUrl(favoriteOffset, favoriteQueueFilter));
             const data = await response.json();
 
             data.champions.forEach((favorite) => {

--- a/app/templates/summoner.html
+++ b/app/templates/summoner.html
@@ -16,7 +16,8 @@
         data-puuid="{{ summoner.puuid }}"
         data-next-offset="{{ matchData.nextOffset }}"
         data-favorite-next-offset="{{ favoriteChampionData.nextOffset }}"
-        data-queue-filter="{{ queue_filter }}"
+        data-match-queue-filter="{{ match_queue_filter }}"
+        data-favorite-queue-filter="{{ favorite_queue_filter }}"
     >
         <section class="top-bar">
             <a href="/" class="home-link">Back to Search</a>
@@ -78,9 +79,9 @@
                 </div>
                 <div class="match-actions">
                     <div class="filter-control">
-                        <select id="favorite-queue-filter" name="queue_filter" class="filter-select" aria-label="Filter favorite champions by queue" data-queue-filter-select>
-                            {% for value, label in queue_filters %}
-                            <option value="{{ value }}" {% if queue_filter == value %}selected{% endif %}>{{ label }}</option>
+                        <select id="favorite-queue-filter" name="favorite_queue_filter" class="filter-select" aria-label="Filter favorite champions by queue">
+                            {% for value, label in favorite_queue_filters %}
+                            <option value="{{ value }}" {% if favorite_queue_filter == value %}selected{% endif %}>{{ label }}</option>
                             {% endfor %}
                         </select>
                     </div>
@@ -127,9 +128,9 @@
                 </div>
                 <div class="match-actions">
                     <div class="filter-control">
-                        <select id="queue-filter" name="queue_filter" class="filter-select" aria-label="Filter matches by queue" data-queue-filter-select>
-                            {% for value, label in queue_filters %}
-                            <option value="{{ value }}" {% if queue_filter == value %}selected{% endif %}>{{ label }}</option>
+                        <select id="match-queue-filter" name="match_queue_filter" class="filter-select" aria-label="Filter matches by queue">
+                            {% for value, label in match_queue_filters %}
+                            <option value="{{ value }}" {% if match_queue_filter == value %}selected{% endif %}>{{ label }}</option>
                             {% endfor %}
                         </select>
                     </div>

--- a/app/templates/summoner.html
+++ b/app/templates/summoner.html
@@ -15,6 +15,7 @@
         data-tagline="{{ summoner.tagline }}"
         data-puuid="{{ summoner.puuid }}"
         data-next-offset="{{ matchData.nextOffset }}"
+        data-favorite-next-offset="{{ favoriteChampionData.nextOffset }}"
         data-queue-filter="{{ queue_filter }}"
     >
         <section class="top-bar">
@@ -97,7 +98,7 @@
                             <th scope="col">KDA</th>
                         </tr>
                     </thead>
-                    <tbody>
+                    <tbody id="favorite-champion-list">
                         {% for favorite in favoriteChampios %}
                         <tr>
                             <td>{{ favorite.champion_name }}</td>
@@ -113,6 +114,9 @@
                     </tbody>
                 </table>
             </div>
+            {% if favoriteChampionData.hasMore %}
+            <button id="load-more-favorites" class="load-more-button" type="button">Load More</button>
+            {% endif %}
         </section>
 
         <section class="matches-section">

--- a/app/templates/summoner.html
+++ b/app/templates/summoner.html
@@ -75,26 +75,39 @@
                 <div>
                     <h2>Favorite Champions</h2>
                 </div>
+                <div class="match-actions">
+                    <div class="filter-control">
+                        <select id="favorite-queue-filter" name="queue_filter" class="filter-select" aria-label="Filter favorite champions by queue" data-queue-filter-select>
+                            {% for value, label in queue_filters %}
+                            <option value="{{ value }}" {% if queue_filter == value %}selected{% endif %}>{{ label }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
             </div>
             <div class="table-shell">
                 <table class="champion-table">
                     <thead>
                         <tr>
                             <th scope="col">Champion</th>
+                            <th scope="col">Queue</th>
                             <th scope="col">Games</th>
                             <th scope="col">Wins</th>
                             <th scope="col">Winrate</th>
+                            <th scope="col">KDA</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for favorite in favoriteChampios %}
                         <tr>
                             <td>{{ favorite.champion_name }}</td>
+                            <td>{{ favorite.queueDescription }}</td>
                             <td>{{ favorite.games_played }}</td>
                             <td>{{ favorite.wins }}</td>
                             <td>
                                 {{ favorite.winrate }}%
                             </td>
+                            <td>{{ "%.2f"|format(favorite.kda) }}</td>
                         </tr>
                         {% endfor %}
                     </tbody>
@@ -110,7 +123,7 @@
                 </div>
                 <div class="match-actions">
                     <div class="filter-control">
-                        <select id="queue-filter" name="queue_filter" class="filter-select" aria-label="Filter matches by queue">
+                        <select id="queue-filter" name="queue_filter" class="filter-select" aria-label="Filter matches by queue" data-queue-filter-select>
                             {% for value, label in queue_filters %}
                             <option value="{{ value }}" {% if queue_filter == value %}selected{% endif %}>{{ label }}</option>
                             {% endfor %}

--- a/app/utils/queue_filters.py
+++ b/app/utils/queue_filters.py
@@ -8,6 +8,7 @@ QUEUE_FILTER_RANKED_SOLO: Final = "ranked_solo"
 QUEUE_FILTER_RANKED_FLEX: Final = "ranked_flex"
 QUEUE_FILTER_ARAM: Final = "aram"
 QUEUE_FILTER_OTHER: Final = "other"
+DEFAULT_FAVORITE_QUEUE_FILTER: Final = QUEUE_FILTER_RANKED_SOLO
 
 QUEUE_FILTER_OPTIONS: Final[list[tuple[str, str]]] = [
     (QUEUE_FILTER_ALL, "All"),
@@ -15,6 +16,12 @@ QUEUE_FILTER_OPTIONS: Final[list[tuple[str, str]]] = [
     (QUEUE_FILTER_RANKED_FLEX, "Ranked Flex"),
     (QUEUE_FILTER_ARAM, "ARAM"),
     (QUEUE_FILTER_OTHER, "Other"),
+]
+
+FAVORITE_QUEUE_FILTER_OPTIONS: Final[list[tuple[str, str]]] = [
+    (QUEUE_FILTER_RANKED_SOLO, "Ranked Solo"),
+    (QUEUE_FILTER_RANKED_FLEX, "Ranked Flex"),
+    (QUEUE_FILTER_ARAM, "ARAM"),
 ]
 
 FILTER_TO_QUEUE_ID: Final[dict[str, int]] = {
@@ -25,6 +32,7 @@ FILTER_TO_QUEUE_ID: Final[dict[str, int]] = {
 
 PRIMARY_QUEUE_IDS: Final[tuple[int, ...]] = tuple(FILTER_TO_QUEUE_ID.values())
 VALID_QUEUE_FILTERS: Final[set[str]] = {value for value, _label in QUEUE_FILTER_OPTIONS}
+FAVORITE_QUEUE_FILTERS: Final[set[str]] = {value for value, _label in FAVORITE_QUEUE_FILTER_OPTIONS}
 
 
 def normalize_queue_filter(queue_filter: str | None) -> str:
@@ -35,6 +43,16 @@ def normalize_queue_filter(queue_filter: str | None) -> str:
     if normalized in VALID_QUEUE_FILTERS:
         return normalized
     return QUEUE_FILTER_ALL
+
+
+def normalize_favorite_queue_filter(queue_filter: str | None) -> str:
+    if not queue_filter:
+        return DEFAULT_FAVORITE_QUEUE_FILTER
+
+    normalized = queue_filter.strip().lower()
+    if normalized in FAVORITE_QUEUE_FILTERS:
+        return normalized
+    return DEFAULT_FAVORITE_QUEUE_FILTER
 
 
 def matches_queue_filter(queue_id: int | None, queue_filter: str | None) -> bool:

--- a/tests/integration/test_summoner_flow_e2e.py
+++ b/tests/integration/test_summoner_flow_e2e.py
@@ -40,8 +40,8 @@ def test_cached_summoner_flow_html_and_ajax(app_client, seed_cached_summoner_dat
 
 @pytest.mark.integration
 def test_cached_summoner_flow_filters_by_queue(app_client, seed_cached_summoner_data):
-    aram_response = app_client.get("/summoner/cached/euw?offset=0&ajax=true&queue_filter=aram")
-    other_response = app_client.get("/summoner/cached/euw?offset=0&ajax=true&queue_filter=other")
+    aram_response = app_client.get("/summoner/cached/euw?offset=0&ajax=true&match_queue_filter=aram")
+    other_response = app_client.get("/summoner/cached/euw?offset=0&ajax=true&match_queue_filter=other")
 
     assert aram_response.status_code == 200
     assert other_response.status_code == 200

--- a/tests/test_dao.py
+++ b/tests/test_dao.py
@@ -688,3 +688,100 @@ def test_get_summoner_champions_filters_by_queue_category(db_session):
     assert [favorite.champion_name for favorite in flex_favorites] == ["Lux"]
     assert [favorite.champion_name for favorite in other_favorites] == ["Jinx"]
 
+
+def test_get_summoner_champions_applies_offset(db_session):
+    dao = DAO(db_session)
+    db_session.add(DaoSummoner(id="player-1", summoner_name="Alpha#EUW", games_played=4, games_won=2, kill=20, death=6, assist=18))
+    db_session.add(Queue(queue_id=420, map="Summoner's Rift", description="Ranked Solo", notes=None))
+    db_session.add_all(
+        [
+            Champion(id="Ahri", champion_name="Ahri"),
+            Champion(id="Lux", champion_name="Lux"),
+            Champion(id="Jinx", champion_name="Jinx"),
+            DaoSummonerChampion(
+                summoner_id="player-1",
+                champion_id="Ahri",
+                queue_id=420,
+                games_played=5,
+                games_won=3,
+                kill=20,
+                death=6,
+                assist=18,
+            ),
+            DaoSummonerChampion(
+                summoner_id="player-1",
+                champion_id="Lux",
+                queue_id=420,
+                games_played=4,
+                games_won=2,
+                kill=12,
+                death=5,
+                assist=22,
+            ),
+            DaoSummonerChampion(
+                summoner_id="player-1",
+                champion_id="Jinx",
+                queue_id=420,
+                games_played=3,
+                games_won=1,
+                kill=18,
+                death=7,
+                assist=8,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    second_page = dao.get_summoner_champions("player-1", 2, "all", offset=1)
+
+    assert [favorite.champion_name for favorite in second_page] == ["Lux", "Jinx"]
+
+
+def test_get_summoner_champions_orders_tied_games_deterministically(db_session):
+    dao = DAO(db_session)
+    db_session.add(DaoSummoner(id="player-1", summoner_name="Alpha#EUW", games_played=4, games_won=2, kill=20, death=6, assist=18))
+    db_session.add(Queue(queue_id=420, map="Summoner's Rift", description="Ranked Solo", notes=None))
+    db_session.add_all(
+        [
+            Champion(id="Lux", champion_name="Lux"),
+            Champion(id="Ahri", champion_name="Ahri"),
+            Champion(id="Jinx", champion_name="Jinx"),
+            DaoSummonerChampion(
+                summoner_id="player-1",
+                champion_id="Lux",
+                queue_id=420,
+                games_played=3,
+                games_won=1,
+                kill=8,
+                death=4,
+                assist=16,
+            ),
+            DaoSummonerChampion(
+                summoner_id="player-1",
+                champion_id="Ahri",
+                queue_id=420,
+                games_played=3,
+                games_won=2,
+                kill=12,
+                death=5,
+                assist=10,
+            ),
+            DaoSummonerChampion(
+                summoner_id="player-1",
+                champion_id="Jinx",
+                queue_id=420,
+                games_played=3,
+                games_won=1,
+                kill=15,
+                death=6,
+                assist=6,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    first_page = dao.get_summoner_champions("player-1", 2, "all", offset=0)
+    second_page = dao.get_summoner_champions("player-1", 2, "all", offset=2)
+
+    assert [favorite.champion_name for favorite in first_page] == ["Ahri", "Jinx"]
+    assert [favorite.champion_name for favorite in second_page] == ["Lux"]

--- a/tests/test_dao.py
+++ b/tests/test_dao.py
@@ -16,6 +16,7 @@ from app.database.models import (
     MatchesAnalyzed,
     Queue,
     Summoner as DaoSummoner,
+    SummonerChampion as DaoSummonerChampion,
     SummonerQueue as DaoSummonerQueue,
 )
 from app.models.summonerModels import Match, MatchParticipant, Summoner, SummonerDivision
@@ -602,3 +603,88 @@ def test_get_champion_rates_use_matches_analyzed(db_session):
     stats = champion.championStats[0]
     assert stats.pickrate == 10
     assert stats.banrate == 2.5
+
+
+def test_get_summoner_champions_returns_queue_and_kda_totals(db_session):
+    dao = DAO(db_session)
+    db_session.add(DaoSummoner(id="player-1", summoner_name="Alpha#EUW", games_played=2, games_won=1, kill=8, death=2, assist=10))
+    db_session.add(Champion(id="Ahri", champion_name="Ahri"))
+    db_session.add(Queue(queue_id=420, map="Summoner's Rift", description="Ranked Solo", notes=None))
+    db_session.add(
+        DaoSummonerChampion(
+            summoner_id="player-1",
+            champion_id="Ahri",
+            queue_id=420,
+            games_played=2,
+            games_won=1,
+            kill=8,
+            death=2,
+            assist=10,
+        )
+    )
+    db_session.commit()
+
+    favorite_champions = dao.get_summoner_champions("player-1", 3)
+
+    assert len(favorite_champions) == 1
+    favorite = favorite_champions[0]
+    assert favorite.queueDescription == "Ranked Solo"
+    assert favorite.kills == 8
+    assert favorite.deaths == 2
+    assert favorite.assists == 10
+    assert favorite.kda == 9
+
+
+def test_get_summoner_champions_filters_by_queue_category(db_session):
+    dao = DAO(db_session)
+    db_session.add(DaoSummoner(id="player-1", summoner_name="Alpha#EUW", games_played=4, games_won=2, kill=20, death=6, assist=18))
+    db_session.add_all(
+        [
+            Champion(id="Ahri", champion_name="Ahri"),
+            Champion(id="Lux", champion_name="Lux"),
+            Champion(id="Jinx", champion_name="Jinx"),
+            Queue(queue_id=420, map="Summoner's Rift", description="Ranked Solo", notes=None),
+            Queue(queue_id=440, map="Summoner's Rift", description="Ranked Flex", notes=None),
+            Queue(queue_id=1700, map="Rings of Wrath", description="Arena", notes=None),
+            DaoSummonerChampion(
+                summoner_id="player-1",
+                champion_id="Ahri",
+                queue_id=420,
+                games_played=5,
+                games_won=3,
+                kill=20,
+                death=6,
+                assist=18,
+            ),
+            DaoSummonerChampion(
+                summoner_id="player-1",
+                champion_id="Lux",
+                queue_id=440,
+                games_played=4,
+                games_won=2,
+                kill=12,
+                death=5,
+                assist=22,
+            ),
+            DaoSummonerChampion(
+                summoner_id="player-1",
+                champion_id="Jinx",
+                queue_id=1700,
+                games_played=3,
+                games_won=1,
+                kill=18,
+                death=7,
+                assist=8,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    solo_favorites = dao.get_summoner_champions("player-1", 3, "ranked_solo")
+    flex_favorites = dao.get_summoner_champions("player-1", 3, "ranked_flex")
+    other_favorites = dao.get_summoner_champions("player-1", 3, "other")
+
+    assert [favorite.champion_name for favorite in solo_favorites] == ["Ahri"]
+    assert [favorite.champion_name for favorite in flex_favorites] == ["Lux"]
+    assert [favorite.champion_name for favorite in other_favorites] == ["Jinx"]
+

--- a/tests/test_summoner_endpoint.py
+++ b/tests/test_summoner_endpoint.py
@@ -65,7 +65,7 @@ def test_summoner_page_found(monkeypatch):
     monkeypatch.setattr(endpoints, "load_summoner_page", lambda request, name, tagline, offset, count, dao, queue_filter: make_page_data())
     # Provide a fake DAO so load_favorite_champions can call dao.get_summoner_champions
     class FakeDAO:
-        def get_summoner_champions(self, summoner_id, count):
+        def get_summoner_champions(self, summoner_id, count, queue_filter="all"):
             return make_SummonerChampion()
 
     fake_dao = FakeDAO()
@@ -101,7 +101,7 @@ def test_summoner_page_links_match_participants(monkeypatch):
         )
     ]
     class FakeDAO:
-        def get_summoner_champions(self, summoner_id, count):
+        def get_summoner_champions(self, summoner_id, count, queue_filter="all"):
             return make_SummonerChampion()
 
     fake_dao = FakeDAO()
@@ -142,7 +142,7 @@ def test_summoner_page_renders_item_icons_in_match_details(monkeypatch):
     ]
 
     class FakeDAO:
-        def get_summoner_champions(self, summoner_id, count):
+        def get_summoner_champions(self, summoner_id, count, queue_filter="all"):
             return make_SummonerChampion()
 
     fake_dao = FakeDAO()
@@ -162,7 +162,7 @@ def test_summoner_page_not_found_redirects(monkeypatch):
         lambda request, name, tagline, offset, count, dao, queue_filter: SummonerPageServiceResult(summoner=None, match_page=None),
     )
     class FakeDAO:
-        def get_summoner_champions(self, summoner_id, count):
+        def get_summoner_champions(self, summoner_id, count, queue_filter="all"):
             return make_SummonerChampion()
 
     fake_dao = FakeDAO()
@@ -178,7 +178,7 @@ def test_summoner_matches_ajax_response(monkeypatch):
     monkeypatch.setattr(endpoints, "load_summoner_page", lambda request, name, tagline, offset, count, dao, queue_filter: make_page_data())
 
     class FakeDAO:
-        def get_summoner_champions(self, summoner_id, count):
+        def get_summoner_champions(self, summoner_id, count, queue_filter="all"):
             return make_SummonerChampion()
 
     fake_dao = FakeDAO()
@@ -204,10 +204,20 @@ def test_summoner_queue_filter_is_forwarded(monkeypatch):
 
     monkeypatch.setattr(endpoints, "load_summoner_page", fake_load_summoner_page)
 
+    class FakeDAO:
+        def get_summoner_champions(self, summoner_id, count, queue_filter="all"):
+            captured["favorite_queue_filter"] = queue_filter
+            return make_SummonerChampion()
+
+    app.dependency_overrides[endpoints.get_dao] = lambda: FakeDAO()
+
     response = client.get("/summoner/test/euw?queue_filter=aram")
+    app.dependency_overrides.pop(endpoints.get_dao, None)
 
     assert response.status_code == 200
     assert captured["queue_filter"] == "aram"
+    assert captured["favorite_queue_filter"] == "aram"
+    assert 'id="favorite-queue-filter"' in response.text
 
 
 def test_not_found_page_displays_searched_summoner():

--- a/tests/test_summoner_endpoint.py
+++ b/tests/test_summoner_endpoint.py
@@ -65,7 +65,7 @@ def test_summoner_page_found(monkeypatch):
     monkeypatch.setattr(endpoints, "load_summoner_page", lambda request, name, tagline, offset, count, dao, queue_filter: make_page_data())
     # Provide a fake DAO so load_favorite_champions can call dao.get_summoner_champions
     class FakeDAO:
-        def get_summoner_champions(self, summoner_id, count, queue_filter="all"):
+        def get_summoner_champions(self, summoner_id, count, queue_filter="all", offset=0):
             return make_SummonerChampion()
 
     fake_dao = FakeDAO()
@@ -101,7 +101,7 @@ def test_summoner_page_links_match_participants(monkeypatch):
         )
     ]
     class FakeDAO:
-        def get_summoner_champions(self, summoner_id, count, queue_filter="all"):
+        def get_summoner_champions(self, summoner_id, count, queue_filter="all", offset=0):
             return make_SummonerChampion()
 
     fake_dao = FakeDAO()
@@ -142,7 +142,7 @@ def test_summoner_page_renders_item_icons_in_match_details(monkeypatch):
     ]
 
     class FakeDAO:
-        def get_summoner_champions(self, summoner_id, count, queue_filter="all"):
+        def get_summoner_champions(self, summoner_id, count, queue_filter="all", offset=0):
             return make_SummonerChampion()
 
     fake_dao = FakeDAO()
@@ -162,7 +162,7 @@ def test_summoner_page_not_found_redirects(monkeypatch):
         lambda request, name, tagline, offset, count, dao, queue_filter: SummonerPageServiceResult(summoner=None, match_page=None),
     )
     class FakeDAO:
-        def get_summoner_champions(self, summoner_id, count, queue_filter="all"):
+        def get_summoner_champions(self, summoner_id, count, queue_filter="all", offset=0):
             return make_SummonerChampion()
 
     fake_dao = FakeDAO()
@@ -178,7 +178,7 @@ def test_summoner_matches_ajax_response(monkeypatch):
     monkeypatch.setattr(endpoints, "load_summoner_page", lambda request, name, tagline, offset, count, dao, queue_filter: make_page_data())
 
     class FakeDAO:
-        def get_summoner_champions(self, summoner_id, count, queue_filter="all"):
+        def get_summoner_champions(self, summoner_id, count, queue_filter="all", offset=0):
             return make_SummonerChampion()
 
     fake_dao = FakeDAO()
@@ -205,7 +205,7 @@ def test_summoner_queue_filter_is_forwarded(monkeypatch):
     monkeypatch.setattr(endpoints, "load_summoner_page", fake_load_summoner_page)
 
     class FakeDAO:
-        def get_summoner_champions(self, summoner_id, count, queue_filter="all"):
+        def get_summoner_champions(self, summoner_id, count, queue_filter="all", offset=0):
             captured["favorite_queue_filter"] = queue_filter
             return make_SummonerChampion()
 
@@ -218,6 +218,52 @@ def test_summoner_queue_filter_is_forwarded(monkeypatch):
     assert captured["queue_filter"] == "aram"
     assert captured["favorite_queue_filter"] == "aram"
     assert 'id="favorite-queue-filter"' in response.text
+
+
+def test_summoner_favorite_champions_ajax_response(monkeypatch):
+    captured = {}
+
+    class FakeDAO:
+        def get_summoner(self, summoner_name):
+            return make_summoner()
+
+        def get_summoner_champions(self, summoner_id, count, queue_filter="all", offset=0):
+            captured["summoner_id"] = summoner_id
+            captured["count"] = count
+            captured["queue_filter"] = queue_filter
+            captured["offset"] = offset
+            return [
+                SummonerChampion(
+                    champion_id=f"champion-{index}",
+                    champion_name=f"Champion {index}",
+                    queueDescription="Ranked Solo",
+                    games_played=10 - index,
+                    wins=5,
+                    kills=20,
+                    deaths=5,
+                    assists=10,
+                )
+                for index in range(count)
+            ]
+
+    app.dependency_overrides[endpoints.get_dao] = lambda: FakeDAO()
+
+    response = client.get("/summoner/test/euw/favorite-champions?offset=3&queue_filter=ranked_solo")
+    app.dependency_overrides.pop(endpoints.get_dao, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["champions"]) == settings.favorite_champion_count
+    assert data["hasMore"] is True
+    assert data["nextOffset"] == 6
+    assert data["champions"][0]["queueDescription"] == "Ranked Solo"
+    assert "queueId" not in data["champions"][0]
+    assert captured == {
+        "summoner_id": "player-puuid",
+        "count": settings.favorite_champion_count + 1,
+        "queue_filter": "ranked_solo",
+        "offset": 3,
+    }
 
 
 def test_not_found_page_displays_searched_summoner():

--- a/tests/test_summoner_endpoint.py
+++ b/tests/test_summoner_endpoint.py
@@ -195,11 +195,11 @@ def test_summoner_matches_ajax_response(monkeypatch):
     assert "queueId" not in data["matches"][0]
 
 
-def test_summoner_queue_filter_is_forwarded(monkeypatch):
+def test_summoner_queue_filters_are_forwarded_independently(monkeypatch):
     captured = {}
 
     def fake_load_summoner_page(request, name, tagline, offset, count, dao, queue_filter):
-        captured["queue_filter"] = queue_filter
+        captured["match_queue_filter"] = queue_filter
         return make_page_data()
 
     monkeypatch.setattr(endpoints, "load_summoner_page", fake_load_summoner_page)
@@ -211,13 +211,16 @@ def test_summoner_queue_filter_is_forwarded(monkeypatch):
 
     app.dependency_overrides[endpoints.get_dao] = lambda: FakeDAO()
 
-    response = client.get("/summoner/test/euw?queue_filter=aram")
+    response = client.get("/summoner/test/euw?match_queue_filter=aram&favorite_queue_filter=ranked_flex")
     app.dependency_overrides.pop(endpoints.get_dao, None)
 
     assert response.status_code == 200
-    assert captured["queue_filter"] == "aram"
-    assert captured["favorite_queue_filter"] == "aram"
+    assert captured["match_queue_filter"] == "aram"
+    assert captured["favorite_queue_filter"] == "ranked_flex"
     assert 'id="favorite-queue-filter"' in response.text
+    assert 'id="match-queue-filter"' in response.text
+    assert response.text.count('<option value="all"') == 1
+    assert response.text.count('<option value="other"') == 1
 
 
 def test_summoner_favorite_champions_ajax_response(monkeypatch):
@@ -248,21 +251,21 @@ def test_summoner_favorite_champions_ajax_response(monkeypatch):
 
     app.dependency_overrides[endpoints.get_dao] = lambda: FakeDAO()
 
-    response = client.get("/summoner/test/euw/favorite-champions?offset=3&queue_filter=ranked_solo")
+    response = client.get("/summoner/test/euw/favorite-champions?offset=5&favorite_queue_filter=ranked_solo")
     app.dependency_overrides.pop(endpoints.get_dao, None)
 
     assert response.status_code == 200
     data = response.json()
-    assert len(data["champions"]) == settings.favorite_champion_count
+    assert len(data["champions"]) == settings.favorite_champion_page_size
     assert data["hasMore"] is True
-    assert data["nextOffset"] == 6
+    assert data["nextOffset"] == 10
     assert data["champions"][0]["queueDescription"] == "Ranked Solo"
     assert "queueId" not in data["champions"][0]
     assert captured == {
         "summoner_id": "player-puuid",
-        "count": settings.favorite_champion_count + 1,
+        "count": settings.favorite_champion_page_size + 1,
         "queue_filter": "ranked_solo",
-        "offset": 3,
+        "offset": 5,
     }
 
 


### PR DESCRIPTION
Frontend update:
- favorite champions on summoner's page can be filtered by 3 selected queues - Ranked Solo (default), Ranked Flex and ARAM
- each favorite champion entry has KDA relative to selected queue.
- pagination with load more option was implemented

Backend update:
- addition of new filter for favorite champions section
- DAO method for getting favorite champions from database was added
- endpoint and service code was updated to handle new filtering

Database update:
- champion_summoner table was updated to have queue_id as part of the primary key
- kill, death, assist attributes were added to champion_summoner table
- new insert trigger, that increments kills, deaths and assists in champion_summoner table, was added for match_participant table