### PR TITLE
Champion page stats queue limitation implemented

### DIFF
--- a/app/services/championServices.py
+++ b/app/services/championServices.py
@@ -7,6 +7,9 @@ from app.utils.versioning import normalize_version, version_sort_key
 import logging
 logger = logging.getLogger(__name__)
 
+CHAMPION_PAGE_QUEUE_IDS = {420, 440, 450}
+CHAMPION_PAGE_QUEUE_DESCRIPTIONS = {"Ranked Solo", "Ranked Flex", "ARAM"}
+
 
 def _empty_aggregate_bucket() -> dict[str, int]:
     return {
@@ -30,12 +33,23 @@ def _accumulate_stat(entry: dict[str, int], stat: ChampionStats) -> None:
     entry["matchesAnalyzed"] += stat.matchesAnalyzed
 
 
+def _is_champion_page_queue(stat: ChampionStats) -> bool:
+    if stat.queueId:
+        return stat.queueId in CHAMPION_PAGE_QUEUE_IDS
+
+    return stat.queueDescription in CHAMPION_PAGE_QUEUE_DESCRIPTIONS
+
+
+def _filter_champion_page_queues(stats: list[ChampionStats]) -> list[ChampionStats]:
+    return [stat for stat in stats if _is_champion_page_queue(stat)]
+
+
 def _aggregate_by_queue_and_version(stats: list[ChampionStats]) -> dict[str, dict[str, dict[str, int]]]:
     grouped: dict[str, dict[str, dict[str, int]]] = defaultdict(
         lambda: defaultdict(_empty_aggregate_bucket)
     )
 
-    for stat in stats:
+    for stat in _filter_champion_page_queues(stats):
         normalized = normalize_version(stat.version)
         _accumulate_stat(grouped[stat.queueDescription][normalized], stat)
 
@@ -44,7 +58,7 @@ def _aggregate_by_queue_and_version(stats: list[ChampionStats]) -> dict[str, dic
 
 def get_available_versions(stats: list[ChampionStats]) -> list[str]:
     return sorted(
-        {normalize_version(stat.version) for stat in stats},
+        {normalize_version(stat.version) for stat in _filter_champion_page_queues(stats)},
         key=version_sort_key,
         reverse=True,
     )

--- a/app/static/js/champion.js
+++ b/app/static/js/champion.js
@@ -184,7 +184,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         if (!rows || rows.length === 0) {
             const row = document.createElement("tr");
-            row.innerHTML = '<td colspan="7">No statistics available for this version.</td>';
+            row.innerHTML = '<td colspan="6">No statistics available for this version.</td>';
             tableBody.appendChild(row);
             return;
         }
@@ -192,11 +192,10 @@ document.addEventListener("DOMContentLoaded", () => {
         rows.forEach((stat) => {
             const row = document.createElement("tr");
             row.innerHTML = `
-                <td>${stat.version}</td>
                 <td>${stat.queueDescription}</td>
                 <td>${stat.totalMatchesPlayed ?? stat.gamesPlayed}</td>
-                <td>${formatNumber(stat.winrate, "%")}</td>
                 <td>${formatNumber(stat.kda)}</td>
+                <td>${formatNumber(stat.winrate, "%")}</td>
                 <td>${formatNumber(stat.pickrate, "%")}</td>
                 <td>${formatNumber(stat.banrate, "%")}</td>
             `;
@@ -336,7 +335,7 @@ document.addEventListener("DOMContentLoaded", () => {
     versionSelect.addEventListener("change", () => {
         loadVersion(versionSelect.value).catch((error) => {
             console.error("Failed to switch champion version.", error);
-            tableBody.innerHTML = `<tr><td colspan="7">${error.message}</td></tr>`;
+            tableBody.innerHTML = `<tr><td colspan="6">${error.message}</td></tr>`;
         });
     });
 
@@ -345,6 +344,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
     loadVersion(initialVersion || versionSelect.value).catch((error) => {
         console.error("Failed to load champion version.", error);
-        tableBody.innerHTML = `<tr><td colspan="7">${error.message}</td></tr>`;
+        tableBody.innerHTML = `<tr><td colspan="6">${error.message}</td></tr>`;
     });
 });

--- a/app/templates/champion.html
+++ b/app/templates/champion.html
@@ -111,11 +111,10 @@
             <div class="table-shell">
                 <table>
                     <tr>
-                        <th>Patch</th>
                         <th>Queue</th>
                         <th>Total Matches Played</th>
-                        <th>Winrate</th>
                         <th>KDA</th>
+                        <th>Winrate</th>
                         <th>Pickrate</th>
                         <th>Banrate</th>
                     </tr>
@@ -123,11 +122,10 @@
                     <tbody id="stats-body">
                     {% for stat in championData.championStats %}
                     <tr>
-                        <td>{{ stat.version }}</td>
                         <td>{{ stat.queueDescription }}</td>
                         <td>{{ stat.gamesPlayed }}</td>
-                        <td>{{ "%.2f"|format(stat.winrate) }}%</td>
                         <td>{{ "%.2f"|format(stat.kda) }}</td>
+                        <td>{{ "%.2f"|format(stat.winrate) }}%</td>
                         <td>{{ "%.2f"|format(stat.pickrate) }}%</td>
                         <td>{{ "%.2f"|format(stat.banrate) }}%</td>
                     </tr>

--- a/tests/test_champion_services.py
+++ b/tests/test_champion_services.py
@@ -168,6 +168,21 @@ def test_aggregate_stats_for_version_sums_modes():
     assert ranked.matchesAnalyzed == 220
 
 
+def test_champion_page_stats_only_include_primary_queues():
+    stats = [
+        ChampionStats(version="16.8.777.3456", queueId=420, queueDescription="Ranked Solo", wins=4, gamesPlayed=10, kills=20, deaths=10, assists=15, banned=2, matchesAnalyzed=100),
+        ChampionStats(version="16.8.777.3456", queueId=440, queueDescription="Ranked Flex", wins=3, gamesPlayed=8, kills=15, deaths=8, assists=12, banned=1, matchesAnalyzed=80),
+        ChampionStats(version="16.8.777.3456", queueId=450, queueDescription="ARAM", wins=5, gamesPlayed=9, kills=25, deaths=12, assists=30, banned=0, matchesAnalyzed=90),
+        ChampionStats(version="16.8.777.3456", queueId=1700, queueDescription="Arena", wins=9, gamesPlayed=12, kills=40, deaths=12, assists=10, banned=0, matchesAnalyzed=70),
+    ]
+
+    aggregated = aggregate_stats_for_version(stats, "16.8")
+    trend_series = build_trend_series(stats)
+
+    assert [stat.queueDescription for stat in aggregated] == ["ARAM", "Ranked Flex", "Ranked Solo"]
+    assert [series["queueDescription"] for series in trend_series] == ["ARAM", "Ranked Flex", "Ranked Solo"]
+
+
 def test_build_trend_series_groups_by_normalized_version():
     stats = [
         ChampionStats(version="16.8.777.3456", queueDescription="Ranked Solo", wins=4, gamesPlayed=10, kills=20, deaths=10, assists=15, banned=2, matchesAnalyzed=100),


### PR DESCRIPTION
Champion page shows stats only for three queues:
- Ranked Solo
- Ranked Flex
- ARAM

Implemented according to issue #82 .